### PR TITLE
Bump disk quota for registry

### DIFF
--- a/src/example-apps/registry/manifest.yml
+++ b/src/example-apps/registry/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: registry
     memory: 2G
-    disk_quota: 32M
+    disk_quota: 128M
     buildpack: go_buildpack
     instances: 1
     env:


### PR DESCRIPTION
We're having cf-networking-release acceptance tests fail due to the registry exceeding the disk quota when deploying.