### PR TITLE
Samples README to remind diego defaults $PORT to 8080

### DIFF
--- a/src/example-apps/eureka/README.md
+++ b/src/example-apps/eureka/README.md
@@ -102,6 +102,8 @@ eureka.instance.nonSecurePort=${PORT}
 This causes the backend instance to report its own address as the internal container-network address and port
 (not the external, NAT'ed address that the router uses to reach it).
 
+Note that Diego always assigns $PORT to 8080 (see [doc](https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#http-vs-tcp-routes)), making it possible for application developers to predict this port, and assign it statically in the backend network policies. 
+
 
 The `backend` reaches the registry at the public address `registry.bosh-lite.com`.
 The `zuul-proxy` is also configured to look up


### PR DESCRIPTION
When reading the README for samples, in particular [eureka](https://github.com/cloudfoundry/cf-networking-release/blob/develop/src/example-apps/eureka/README.md) and [proxy](https://github.com/cloudfoundry/cf-networking-release/tree/develop/src/example-apps/proxy), it was for me hard to understand how the backend application can listen on the 8080 port whereas port 8080 seems not specified by the backend app, and the backend registers with eureka using $PORT.

In particular, the README did not make it clear for me that the policies specified by application team that open port on 8080 would allow traffic if $PORT was assigned a different value by diego. 

Especially as https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#PORT still mentions the following (I'm opening a distinct issue for this)

```
PORT
The port on which the app should listen for requests. 
[...]
Example: PORT=61857

```
I finally understood that diego always assigns $PORT to 8080 as documented onto https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html

This minor readme PR tries to clarify this aspect 