### PR TITLE
Add optional `skip_icmp_tests` to acceptance-tests

### DIFF
--- a/src/cf-pusher/config/config.go
+++ b/src/cf-pusher/config/config.go
@@ -19,5 +19,6 @@ type Config struct {
 	ProxyApplications       int      `json:"proxy_applications"`
 	ProxyInstances          int      `json:"proxy_instances"`
 	SamplePercent           int      `json:"sample_percent"`
+	SkipICMPTests           bool     `json:"skip_icmp_tests"`
 	SkipSSLValidation       bool     `json:"skip_ssl_validation"`
 }

--- a/src/test/acceptance/external_connectivity_test.go
+++ b/src/test/acceptance/external_connectivity_test.go
@@ -113,6 +113,9 @@ var _ = Describe("external connectivity", func() {
 			Eventually(cannotProxy, "10s", "1s").Should(Succeed())
 			Consistently(cannotProxy, "2s", "0.5s").Should(Succeed())
 
+			By("checking that the app cannot ping the internet (first time)")
+			Consistently(cannotPing, "2s", "0.5s").Should(Succeed())
+
 			By("creating and binding a tcp and udp security group")
 			Expect(cli.BindSecurityGroup("tcp-asg", orgName, spaceName)).To(Succeed())
 			Expect(cli.BindSecurityGroup("udp-asg", orgName, spaceName)).To(Succeed())
@@ -123,6 +126,9 @@ var _ = Describe("external connectivity", func() {
 			By("checking that the app can use dns and http to reach the internet")
 			Eventually(canProxy, "10s", "1s").Should(Succeed())
 			Consistently(canProxy, "2s", "0.5s").Should(Succeed())
+
+			By("checking that the app cannot ping the internet (second time)")
+			Consistently(cannotPing, "2s", "1s").Should(Succeed())
 
 			By("removing the tcp security groups")
 			Expect(cli.UnbindSecurityGroup("tcp-asg", orgName, spaceName)).To(Succeed())

--- a/src/test/acceptance/external_connectivity_test.go
+++ b/src/test/acceptance/external_connectivity_test.go
@@ -113,9 +113,6 @@ var _ = Describe("external connectivity", func() {
 			Eventually(cannotProxy, "10s", "1s").Should(Succeed())
 			Consistently(cannotProxy, "2s", "0.5s").Should(Succeed())
 
-			By("checking that the app cannot ping the internet (first time)")
-			Consistently(cannotPing, "2s", "0.5s").Should(Succeed())
-
 			By("creating and binding a tcp and udp security group")
 			Expect(cli.BindSecurityGroup("tcp-asg", orgName, spaceName)).To(Succeed())
 			Expect(cli.BindSecurityGroup("udp-asg", orgName, spaceName)).To(Succeed())
@@ -127,14 +124,28 @@ var _ = Describe("external connectivity", func() {
 			Eventually(canProxy, "10s", "1s").Should(Succeed())
 			Consistently(canProxy, "2s", "0.5s").Should(Succeed())
 
-			By("checking that the app cannot ping the internet (second time)")
-			Consistently(cannotPing, "2s", "1s").Should(Succeed())
+			By("removing the tcp security groups")
+			Expect(cli.UnbindSecurityGroup("tcp-asg", orgName, spaceName)).To(Succeed())
+
+			By("restarting the app")
+			Expect(cf.Cf("restart", appA).Wait(Timeout_Push)).To(gexec.Exit(0))
+
+			By("checking that the app cannot use http to reach the internet")
+			Consistently(cannotProxy, "2s", "0.5s").Should(Succeed())
+
+			close(done)
+		}, 180 /* <-- overall spec timeout in seconds */)
+
+		It("allows outbound ICMP only if allowed", func(done Done) {
+			if testConfig.SkipICMPTests {
+				Skip("Test config has 'skip_icmp_test: true', skipping ICMP connectivity tests")
+			}
+
+			By("checking that the app cannot ping the internet")
+			Consistently(cannotPing, "2s", "0.5s").Should(Succeed())
 
 			By("creating and binding an icmp security group")
 			Expect(cli.BindSecurityGroup("icmp-asg", orgName, spaceName)).To(Succeed())
-
-			By("removing the tcp security groups")
-			Expect(cli.UnbindSecurityGroup("tcp-asg", orgName, spaceName)).To(Succeed())
 
 			By("restarting the app")
 			Expect(cf.Cf("restart", appA).Wait(Timeout_Push)).To(gexec.Exit(0))
@@ -142,9 +153,6 @@ var _ = Describe("external connectivity", func() {
 			By("checking that the app can ping the internet")
 			Eventually(canPing, "10s", "1s").Should(Succeed())
 			Consistently(canPing, "2s", "0.5s").Should(Succeed())
-
-			By("checking that the app cannot use http to reach the internet")
-			Consistently(cannotProxy, "2s", "0.5s").Should(Succeed())
 
 			close(done)
 		}, 180 /* <-- overall spec timeout in seconds */)


### PR DESCRIPTION
Context:

- When using Azure NAT boxes, outbound ICMP does not work
- This flag allows us to skip these tests on Azure envs

Dev Notes:

- We assumed that the TCP/UDP testing was independent of ICMP testing so
  we split out ICMP expectations into a separate test. Feel free to let us
  know if these expectations have some inter-dependence.

Signed-off-by: Kalai Wei <kawei@pivotal.io>