### PR TITLE
Use /proc/self/fd/3 for netNS when pid == 0

### DIFF
--- a/src/garden-external-networker/integration/error_handling_test.go
+++ b/src/garden-external-networker/integration/error_handling_test.go
@@ -80,18 +80,6 @@ var _ = Describe("Garden External Networker errors", func() {
 			})
 		})
 
-		Context("when the stdin JSON is missing a pid field", func() {
-			It("should exit status 1 and print an error to stderr", func() {
-				command.Stdin = strings.NewReader(`{ "something": 12 }`)
-				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(session, "2s").Should(gexec.Exit(1))
-				Expect(session.Out.Contents()).To(BeEmpty())
-				Expect(string(session.Err.Contents())).To(ContainSubstring("prefix: up missing pid"))
-			})
-		})
-
 		Context("when the provided pid is not an integer", func() {
 			It("should exit status 1 and print an error to stderr", func() {
 				command.Stdin = strings.NewReader(`{ "pid": "not-a-number"  }`)
@@ -114,6 +102,18 @@ var _ = Describe("Garden External Networker errors", func() {
 				Eventually(session).Should(gexec.Exit(1))
 				Expect(session.Out.Contents()).To(BeEmpty())
 				Expect(string(session.Err.Contents())).To(ContainSubstring(`prefix: unrecognized action: some-invalid-action`))
+			})
+		})
+
+		Context("when neither a valid pid or fd3 are provided", func() {
+			It("should exit status 1 and print an error to stderr", func() {
+				command.Stdin = strings.NewReader(`{ "pid": 0 }`)
+				session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Out.Contents()).To(BeEmpty())
+				Expect(session.Err.Contents()).NotTo(BeEmpty())
 			})
 		})
 

--- a/src/garden-external-networker/manager/manager.go
+++ b/src/garden-external-networker/manager/manager.go
@@ -62,14 +62,15 @@ type UpOutputs struct {
 }
 
 func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error) {
-	if inputs.Pid == 0 {
-		return nil, errors.New("up missing pid")
-	}
 	if containerHandle == "" {
 		return nil, errors.New("up missing container handle")
 	}
 
 	procNsPath := fmt.Sprintf("/proc/%d/ns/net", inputs.Pid)
+	if inputs.Pid == 0 {
+		procNsPath = fmt.Sprintf("/proc/self/fd/3")
+	}
+
 	bindMountPath := filepath.Join(m.BindMountRoot, containerHandle)
 
 	err := m.Mounter.IdempotentlyMount(procNsPath, bindMountPath)

--- a/src/garden-external-networker/manager/manager_test.go
+++ b/src/garden-external-networker/manager/manager_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Manager", func() {
 	})
 
 	Describe("Up", func() {
-		It("should ensure that the netNS is mounted to the provided path", func() {
+		It("ensures that the netNS is mounted via /proc/pid/ns/net to the provided path", func() {
 			_, err := mgr.Up(containerHandle, upInputs)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -113,6 +113,22 @@ var _ = Describe("Manager", func() {
 			source, target := mounter.IdempotentlyMountArgsForCall(0)
 			Expect(source).To(Equal("/proc/42/ns/net"))
 			Expect(target).To(Equal(filepath.Join("some", "fake", "path", containerHandle)))
+		})
+
+		Context("when the pid is 0", func() {
+			BeforeEach(func() {
+				upInputs.Pid = 0
+			})
+
+			It("ensures that the netNS is mounted via /proc/self/fd/3 to the provided path", func() {
+				_, err := mgr.Up(containerHandle, upInputs)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(mounter.IdempotentlyMountCallCount()).To(Equal(1))
+				source, target := mounter.IdempotentlyMountArgsForCall(0)
+				Expect(source).To(Equal("/proc/self/fd/3"))
+				Expect(target).To(Equal(filepath.Join("some", "fake", "path", containerHandle)))
+			})
 		})
 
 		It("should create proxy redirect rules in the container namespace", func() {
@@ -238,7 +254,6 @@ var _ = Describe("Manager", func() {
 					NetOut:     netOutRules,
 					NetIn:      netInRules,
 				})
-				Expect(err).To(MatchError("up missing pid"))
 
 				_, err = mgr.Up("", upInputs)
 				Expect(err).To(MatchError("up missing container handle"))


### PR DESCRIPTION
Hi cf-networking team!

This change allows the garden-external-networker to be run via
[netplugin-server](https://github.com/cloudfoundry/garden-runc-release/tree/9770031121dd27a4b676fb1f911243397137deb8/jobs/netplugin-server), which is configured to run when garden BPM is enabled.

[#158594265]

Co-authored-by: Oliver Stenbom <ostenbom@pivotal.io>
Co-authored-by: Julia Nedialkova <julianedialkova@hotmail.com>