### PR TITLE
GetSubjectSpaces iterates paginated responses

### DIFF
--- a/src/policy-server/cc_client/client.go
+++ b/src/policy-server/cc_client/client.go
@@ -288,9 +288,13 @@ func (c *Client) GetSubjectSpace(token, subjectId string, space api.Space) (*api
 }
 
 func (c *Client) GetSubjectSpaces(token, subjectId string) (map[string]struct{}, error) {
+	const maximumPageSize = "100"
 	token = fmt.Sprintf("bearer %s", token)
 
-	route := fmt.Sprintf("/v2/users/%s/spaces", subjectId)
+	values := url.Values{}
+	values.Add("results-per-page", maximumPageSize)
+
+	route := fmt.Sprintf("/v2/users/%s/spaces?%s", subjectId, values.Encode())
 
 	var resources []SpaceResource
 	for route != "" {

--- a/src/policy-server/cc_client/client_test.go
+++ b/src/policy-server/cc_client/client_test.go
@@ -439,7 +439,8 @@ var _ = Describe("Client", func() {
 				page, err := strconv.Atoi(pageParameter)
 				Expect(err).NotTo(HaveOccurred())
 				response := responses[page - 1]
-				_ = json.Unmarshal([]byte(response), respData)
+				err = json.Unmarshal([]byte(response), respData)
+				Expect(err).NotTo(HaveOccurred())
 				return nil
 			}
 		})
@@ -453,7 +454,7 @@ var _ = Describe("Client", func() {
 			method, route, reqData, _, token := fakeJSONClient.DoArgsForCall(0)
 
 			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/users/some-subject-id/spaces"))
+			Expect(route).To(Equal("/v2/users/some-subject-id/spaces?results-per-page=100"))
 			Expect(reqData).To(BeNil())
 			Expect(token).To(Equal("bearer some-token"))
 

--- a/src/policy-server/cc_client/fixtures/user_space.go
+++ b/src/policy-server/cc_client/fixtures/user_space.go
@@ -100,3 +100,103 @@ const SubjectSpaces = `{
     }
   ]
 }`
+
+const SubjectSpacesPage1 = `{
+  "total_results": 3,
+  "total_pages": 3,
+  "prev_url": null,
+  "next_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=2&results-per-page=1",
+  "resources": [
+    {
+      "metadata": {
+        "guid": "space-1-guid",
+        "url": "/v2/spaces/space-1-guid",
+        "created_at": "2016-06-08T16:41:40Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "space-1-name",
+        "organization_guid": "org-1-guid",
+        "space_quota_definition_guid": null,
+        "allow_ssh": true,
+        "organization_url": "/v2/organizations/org-1-guid",
+        "developers_url": "/v2/spaces/space-1-guid/developers",
+        "managers_url": "/v2/spaces/space-1-guid/managers",
+        "auditors_url": "/v2/spaces/space-1-guid/auditors",
+        "apps_url": "/v2/spaces/space-1-guid/apps",
+        "routes_url": "/v2/spaces/space-1-guid/routes",
+        "domains_url": "/v2/spaces/space-1-guid/domains",
+        "service_instances_url": "/v2/spaces/space-1-guid/service_instances",
+        "app_events_url": "/v2/spaces/space-1-guid/app_events",
+        "events_url": "/v2/spaces/space-1-guid/events",
+        "security_groups_url": "/v2/spaces/space-1-guid/security_groups"
+      }
+    }
+  ]
+}`
+const SubjectSpacesPage2 = `{
+  "total_results": 3,
+  "total_pages": 3,
+  "prev_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=1&results-per-page=1",
+  "next_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=3&results-per-page=1",
+  "resources": [
+    {
+      "metadata": {
+        "guid": "space-2-guid",
+        "url": "/v2/spaces/space-2-guid",
+        "created_at": "2016-06-08T16:41:40Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "space-2-name",
+        "organization_guid": "org-2-guid",
+        "space_quota_definition_guid": null,
+        "allow_ssh": true,
+        "organization_url": "/v2/organizations/org-2-guid",
+        "developers_url": "/v2/spaces/space-2-guid/developers",
+        "managers_url": "/v2/spaces/space-2-guid/managers",
+        "auditors_url": "/v2/spaces/space-2-guid/auditors",
+        "apps_url": "/v2/spaces/space-2-guid/apps",
+        "routes_url": "/v2/spaces/space-2-guid/routes",
+        "domains_url": "/v2/spaces/space-2-guid/domains",
+        "service_instances_url": "/v2/spaces/space-2-guid/service_instances",
+        "app_events_url": "/v2/spaces/space-2-guid/app_events",
+        "events_url": "/v2/spaces/space-2-guid/events",
+        "security_groups_url": "/v2/spaces/space-2-guid/security_groups"
+      }
+    }
+  ]
+}`
+const SubjectSpacesPage3 = `{
+  "total_results": 3,
+  "total_pages": 3,
+  "prev_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=2&results-per-page=1",
+  "next_url": null,
+  "resources": [
+    {
+      "metadata": {
+        "guid": "space-3-guid",
+        "url": "/v2/spaces/space-3-guid",
+        "created_at": "2016-06-08T16:41:40Z",
+        "updated_at": "2016-06-08T16:41:26Z"
+      },
+      "entity": {
+        "name": "space-3-name",
+        "organization_guid": "org-3-guid",
+        "space_quota_definition_guid": null,
+        "allow_ssh": true,
+        "organization_url": "/v2/organizations/org-3-guid",
+        "developers_url": "/v2/spaces/space-3-guid/developers",
+        "managers_url": "/v2/spaces/space-3-guid/managers",
+        "auditors_url": "/v2/spaces/space-3-guid/auditors",
+        "apps_url": "/v2/spaces/space-3-guid/apps",
+        "routes_url": "/v2/spaces/space-3-guid/routes",
+        "domains_url": "/v2/spaces/space-3-guid/domains",
+        "service_instances_url": "/v2/spaces/space-3-guid/service_instances",
+        "app_events_url": "/v2/spaces/space-3-guid/app_events",
+        "events_url": "/v2/spaces/space-3-guid/events",
+        "security_groups_url": "/v2/spaces/space-3-guid/security_groups"
+      }
+    }
+  ]
+}`


### PR DESCRIPTION
Fixes #59.

The CC api would paginate the responses for multiple resources
including the spaces that a user belongs to. The default
pagination size is 50 elements.

If a user belongs to more than 50 spaces, the verification of
policies that the user has access to might fail, as not all the
spaces are retrieved properly.

This commit fixes the specific method cc_client.GetSubjectSpaces,
but a better approach would be create a PaginatedJSONClient
that would wrap json_client.JsonClient to iterate any
paginated response, but that might require more changes across
the code.