### PR TITLE
Make cc ca cert optional when pulling it from cc provided link

### DIFF
--- a/jobs/policy-server/templates/cc_ca.crt.erb
+++ b/jobs/policy-server/templates/cc_ca.crt.erb
@@ -1,3 +1,5 @@
 <% if_link("cloud_controller_https_endpoint") do |cc| %>
-<%= cc.p("cc.public_tls.ca_cert") %>
+<% cc.if_p("cc.public_tls.ca_cert") do |ca_cert| %>
+<%= ca_cert %>
+<% end %>
 <% end %>


### PR DESCRIPTION
- it is not a required property on cc provided link
- if not provided, template interpolation fails

We also noticed that [the policy-server.json.erb code to configure the cc url](https://github.com/cloudfoundry/cf-networking-release/blob/5bdcde1ba25e63140976eb468cb284039589359a/jobs/policy-server/templates/policy-server.json.erb#L46-L52) seems to prefer the http url over the https one if both are provided.

This is related to [this Diego story](https://www.pivotaltracker.com/story/show/159803355) where we are implementing the same functionality

This change may not be complete, there may also be policy server code changes required? We thought we would send in this PR to bring it to your attention for now

cc @mariash 