### PR TITLE
garden-cni: Fix a race when creating a directory

### DIFF
--- a/jobs/garden-cni/templates/pre-start.erb
+++ b/jobs/garden-cni/templates/pre-start.erb
@@ -1,3 +1,4 @@
 #!/bin/bash -eu
 
 rm -rf /var/vcap/data/garden-cni || true
+mkdir -m 700 /var/vcap/data/garden-cni


### PR DESCRIPTION
Ensure proper permissions on /var/vcap/data/garden-cni directory by recreating it from pre-start script right after it's deletion.

Links:
- https://github.com/cloudfoundry/cf-networking-release/issues/65