### PR TITLE
sdc: bpm open_files (ulimit) is configurable

### DIFF
--- a/jobs/service-discovery-controller/spec
+++ b/jobs/service-discovery-controller/spec
@@ -71,6 +71,3 @@ properties:
     example: |
       - 192.168.50.123
       - 192.168.52.123
-
-  open_files:
-    description: "File descriptor limit, increase this to handle more concurrent requests"

--- a/jobs/service-discovery-controller/spec
+++ b/jobs/service-discovery-controller/spec
@@ -71,3 +71,6 @@ properties:
     example: |
       - 192.168.50.123
       - 192.168.52.123
+
+  open_files:
+    description: "File descriptor limit, increase this to handle more concurrent requests"

--- a/jobs/service-discovery-controller/templates/bpm.yml.erb
+++ b/jobs/service-discovery-controller/templates/bpm.yml.erb
@@ -5,3 +5,8 @@ processes:
     args:
       - -c
       - /var/vcap/jobs/service-discovery-controller/config/config.json
+
+    <% if_p('open_files') do %>
+    limits:
+      open_files: <%= p('open_files') %>
+    <% end %>

--- a/jobs/service-discovery-controller/templates/bpm.yml.erb
+++ b/jobs/service-discovery-controller/templates/bpm.yml.erb
@@ -5,8 +5,5 @@ processes:
     args:
       - -c
       - /var/vcap/jobs/service-discovery-controller/config/config.json
-
-    <% if_p('open_files') do %>
     limits:
-      open_files: <%= p('open_files') %>
-    <% end %>
+      open_files: 65535

--- a/spec/service-discovery-controller/service_discovery_controller_spec.rb
+++ b/spec/service-discovery-controller/service_discovery_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+module Bosh::Template::Test
+  describe 'service-discovery-controller job template rendering' do
+    let(:release_path) { File.join(File.dirname(__FILE__), '../..') }
+    let(:release) { ReleaseDir.new(release_path) }
+    let(:job) { release.job('service-discovery-controller') }
+
+    describe 'bpm.yml' do
+      let(:template) { job.template('config/bpm.yml') }
+
+      context 'when open_files is not set' do
+        let(:config) { YAML.safe_load(template.render({}, consumes: [])) }
+
+        it 'does not set the open file descriptor limit' do
+          expect(config['processes'][0].dig('limits', 'open_files')).to be_nil
+        end
+      end
+
+      context 'when open_files is set' do
+        let(:config) {
+          YAML.safe_load(template.render(
+            {
+              'open_files' => 4096
+            },
+            consumes: []
+          ))
+        }
+
+        it 'does not set the open file descriptor limit' do
+          expect(config['processes'][0].dig('limits', 'open_files')).to eq(4096)
+        end
+      end
+    end
+  end
+end

--- a/spec/service-discovery-controller/service_discovery_controller_spec.rb
+++ b/spec/service-discovery-controller/service_discovery_controller_spec.rb
@@ -11,28 +11,10 @@ module Bosh::Template::Test
 
     describe 'bpm.yml' do
       let(:template) { job.template('config/bpm.yml') }
+      let(:config) { YAML.safe_load(template.render({}, consumes: [])) }
 
-      context 'when open_files is not set' do
-        let(:config) { YAML.safe_load(template.render({}, consumes: [])) }
-
-        it 'does not set the open file descriptor limit' do
-          expect(config['processes'][0].dig('limits', 'open_files')).to be_nil
-        end
-      end
-
-      context 'when open_files is set' do
-        let(:config) {
-          YAML.safe_load(template.render(
-            {
-              'open_files' => 4096
-            },
-            consumes: []
-          ))
-        }
-
-        it 'does not set the open file descriptor limit' do
-          expect(config['processes'][0].dig('limits', 'open_files')).to eq(4096)
-        end
+      it 'sets the open file descriptor limit' do
+        expect(config['processes'][0].dig('limits', 'open_files')).to eq(65535)
       end
     end
   end


### PR DESCRIPTION
What
----

- Allow an operator to configure the open_files bpm limit for service-discovery-controller
- Add spec tests for service-discovery-controller bpm template

Context
-------

See https://github.com/alphagov/paas-cf/pull/2358 for more context

So that service-discovery-controller can handle more concurrent (mTLS) DNS requests, we need to increase the number of file descriptors available to the process

This is controlled by bpm, but previously was not set, which gave it the default OS setting (in my case 1024). now an operator is able to configure this setting.

I think this should be hardcoded to 65535, as it is for bosh-dns-adapter, if y'all agree then I'll update this PR

Checklist
---------

- [x] Signed the CLA
- [x] Added tests
- [ ] Discuss with cf-networking team if we can hardcode limit to 65535