### PR TITLE
bosh-dns-adapter/sdcclient: delay retries

### DIFF
--- a/src/bosh-dns-adapter/sdcclient/service_discovery_client_test.go
+++ b/src/bosh-dns-adapter/sdcclient/service_discovery_client_test.go
@@ -2,6 +2,7 @@ package sdcclient_test
 
 import (
 	"net/http"
+	"time"
 
 	. "bosh-dns-adapter/sdcclient"
 	"test-helpers"
@@ -237,10 +238,17 @@ var _ = Describe("ServiceDiscoveryClient", func() {
 			})
 
 			It("retries and returns the successful response", func() {
+				startTime := time.Now()
 				actualIPs, err := client.IPs("app-id.apps.internal.")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(actualIPs).To(ConsistOf("192.168.0.1", "192.168.0.2"))
+
+				timeTaken := time.Now().Sub(startTime).Seconds()
+				Expect(timeTaken).To(
+					BeNumerically("~", 2, 1),
+					"Retries should not be immediate",
+				)
 			})
 		})
 
@@ -263,9 +271,17 @@ var _ = Describe("ServiceDiscoveryClient", func() {
 			})
 
 			It("returns an error", func() {
+				startTime := time.Now()
 				_, err := client.IPs("app-id.apps.internal.")
+
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Received non successful response from server:"))
+
+				timeTaken := time.Now().Sub(startTime).Seconds()
+				Expect(timeTaken).To(
+					BeNumerically("~", 2, 1),
+					"Retries should not be immediate",
+				)
 			})
 		})
 	})


### PR DESCRIPTION
What
----

Introduce a delay between bosh-dns-adapter retries, to reduce the risk of denial-of-service

Context
-------

See https://github.com/alphagov/paas-cf/pull/2358 for more context

We experienced pathological retry behaviour from bosh-dns-adapter when talking to the service-discovery-controller

If a request did not return 200 it immediately retried without any delay or backoff

This caused a spike in load that then cascaded to another instance of service-discovery-controller

Adding a 0/500/1000 delay with jitter, to reduce the risk of cascading failure

Checklist
---------

- [x] Signed the CLA
- [x] Added tests