### PR TITLE
🐞 Example app `proxy` has correct handler paths

### DIFF
--- a/src/example-apps/proxy/main.go
+++ b/src/example-apps/proxy/main.go
@@ -23,12 +23,12 @@ func main() {
 	mux.Handle("/digudp/", &handlers.DigUDPHandler{})
 	mux.Handle("/download/", &handlers.DownloadHandler{})
 	mux.Handle("/dumprequest/", &handlers.DumpRequestHandler{})
-	mux.Handle("/echosourceip/", &handlers.EchoSourceIPHandler{})
+	mux.Handle("/echosourceip", &handlers.EchoSourceIPHandler{})
 	mux.Handle("/ping/", &handlers.PingHandler{})
 	mux.Handle("/proxy/", &handlers.ProxyHandler{Stats: stats})
-	mux.Handle("/stats/", &handlers.StatsHandler{Stats: stats})
+	mux.Handle("/stats", &handlers.StatsHandler{Stats: stats})
 	mux.Handle("/timed_dig/", &handlers.TimedDigHandler{})
-	mux.Handle("/upload/", &handlers.UploadHandler{})
+	mux.Handle("/upload", &handlers.UploadHandler{})
 
 	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), mux)
 }


### PR DESCRIPTION
A [recent refactor](https://github.com/cloudfoundry/cf-networking-release/commit/10cd726bed8fa4c6204ba85daf7872d74b2be8e8) of the example app `proxy` accidentally introduced trailing slashes to three endpoints:

- `/echosourceip`
- `/stats`
- `/upload`

This commit removes the trailing slashes, for they caused at least one test to fail (`src/test/acceptance/source_ip_test.go:53`). The test hits the `/echosourceip` endpoint, _without the trailing slash_, which returns an incorrect 301 status.

fixes <https://ci.nsx-t.cf-app.com/teams/main/pipelines/tas-2.10-ncp-3.0.2-nsx-3.0.0/jobs/run-nats/builds/24>:
```
c2c traffic source ip
/tmp/build/29505db7/cf-networking/src/test/acceptance/source_ip_test.go:14
  should be the container's ip [It]
  /tmp/build/29505db7/cf-networking/src/test/acceptance/source_ip_test.go:46

  Expected
      <string>: <a href="/echosourceip/">Moved Permanently</a>.

  to contain substring
      <string>: 10.12.1.3

  /tmp/build/29505db7/cf-networking/src/test/acceptance/source_ip_test.go:53
```