### PR TITLE
Add TLS NATS support to service-discovery-controller

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -160,3 +160,6 @@
 [submodule "src/google.golang.org/grpc"]
 	path = src/google.golang.org/grpc
 	url = https://github.com/grpc/grpc-go
+[submodule "src/code.cloudfoundry.org/tlsconfig"]
+	path = src/code.cloudfoundry.org/tlsconfig
+	url = https://github.com/cloudfoundry/tlsconfig

--- a/jobs/service-discovery-controller/spec
+++ b/jobs/service-discovery-controller/spec
@@ -8,6 +8,9 @@ templates:
   server.crt.erb:                           config/certs/server.crt
   server.key.erb:                           config/certs/server.key
   client_ca.crt.erb:                        config/certs/client_ca.crt
+  nats_ca_certs.crt.erb:                    config/certs/nats_ca_certs.crt
+  nats_cert_chain.crt.erb:                  config/certs/nats_cert_chain.crt
+  nats_private_key.key.erb:                 config/certs/nats_private_key.key
 
 packages:
   - service-discovery-controller
@@ -22,6 +25,9 @@ provides:
 consumes:
 - name: nats
   type: nats
+  optional: true
+- name: nats-tls
+  type: nats-tls
   optional: true
 
 properties:
@@ -71,3 +77,12 @@ properties:
     example: |
       - 192.168.50.123
       - 192.168.52.123
+  nats.tls_enabled:
+    description: When enabled, Gorouter will prefer to connect to NATS over TLS
+    default: false
+  nats.ca_certs:
+    description: "String of concatenated certificate authorities in PEM format, used to validate certificates presented by NATS."
+  nats.cert_chain:
+    description: Certificate chain used for client authentication to NATS. In PEM format.
+  nats.private_key:
+    description: Private key used for client authentication to NATS. In PEM format.

--- a/jobs/service-discovery-controller/templates/config.json.erb
+++ b/jobs/service-discovery-controller/templates/config.json.erb
@@ -25,38 +25,47 @@ config = {
     'warm_duration_seconds' => route_emitter_interval_seconds
 }
 
+config['nats'] = {}
+nats_link_name = 'nats'
+
+if p('nats.tls_enabled')
+  nats_link_name = 'nats-tls'
+
+  config['nats']['tls_enabled'] = true
+  config['nats']['ca_certs'] = '/var/vcap/jobs/service-discovery-controller/config/certs/nats_ca_certs.crt'
+  config['nats']['cert_chain'] = '/var/vcap/jobs/service-discovery-controller/config/certs/nats_cert_chain.crt'
+  config['nats']['private_key'] = '/var/vcap/jobs/service-discovery-controller/config/certs/nats_private_key.key'
+end
+
+if_p('nats.user') do |prop|
+  config['nats']['user'] = prop
+end.else do
+  config['nats']['user'] = link(nats_link_name).p('nats.user', '')
+end
+if_p('nats.password') do |prop|
+  config['nats']['pass'] = prop
+end.else do
+  config['nats']['pass'] = link(nats_link_name).p('nats.password', '')
+end
+
 nats_machines = nil
 if_p('nats.machines') do |ips|
   nats_machines = ips.compact
 end.else do
-  nats_machines = link('nats').instances.map { |instance| instance.address }
+  link(nats_link_name).if_p("nats.hostname") do |hostname|
+    nats_machines = [hostname]
+  end.else do
+    nats_machines = link(nats_link_name).instances.map { |instance| instance.address }
+  end
 end
 nats_port = nil
 if_p('nats.port') do |prop|
   nats_port = prop
 end.else do
-  nats_port = link('nats').p('nats.port')
+  nats_port = link(nats_link_name).p('nats.port')
 end
-nats_user = nil
-if_p('nats.user') do |prop|
-  nats_user = prop
-end.else do
-  nats_user = link('nats').p('nats.user')
-end
-nats_password = nil
-if_p('nats.password') do |prop|
-  nats_password = prop
-end.else do
-  nats_password = link('nats').p('nats.password')
-end
-
-config['nats'] = nats_machines.map do |nats_machine|
-    {
-     'host' => nats_machine,
-     'port' => nats_port,
-     'user' => nats_user,
-     'pass' => nats_password
-    }
+config['nats']['hosts'] = nats_machines.map do |nats_machine|
+  {'hostname' => nats_machine, 'port' => nats_port}
 end
 
 require 'json'

--- a/jobs/service-discovery-controller/templates/nats_ca_certs.crt.erb
+++ b/jobs/service-discovery-controller/templates/nats_ca_certs.crt.erb
@@ -1,0 +1,7 @@
+<% if_p('nats.ca_certs') do |ca_certs| %>
+<%= ca_certs %>
+<% end.else do %>
+<% if_link("nats-tls") do |nats_tls| %>
+<%= nats_tls.p('nats.external.tls.ca') %>
+<% end %>
+<% end %>

--- a/jobs/service-discovery-controller/templates/nats_cert_chain.crt.erb
+++ b/jobs/service-discovery-controller/templates/nats_cert_chain.crt.erb
@@ -1,0 +1,1 @@
+<% if_p('nats.cert_chain') do |cert_chain| %><%= cert_chain %><% end %>

--- a/jobs/service-discovery-controller/templates/nats_private_key.key.erb
+++ b/jobs/service-discovery-controller/templates/nats_private_key.key.erb
@@ -1,0 +1,1 @@
+<% if_p('nats.private_key') do |private_key| %><%= private_key %><% end %>

--- a/packages/service-discovery-controller/spec
+++ b/packages/service-discovery-controller/spec
@@ -14,6 +14,8 @@ files:
   - code.cloudfoundry.org/clock/*.go # gosub
   - code.cloudfoundry.org/lager/*.go # gosub
   - code.cloudfoundry.org/lager/lagerflags/*.go # gosub
+  - code.cloudfoundry.org/tlsconfig/*.go # gosub
+  - code.cloudfoundry.org/tlsconfig/certtest/*.go # gosub
   - github.com/bmizerany/pat/*.go # gosub
   - github.com/cf-container-networking/sql-migrate/*.go # gosub
   - github.com/cf-container-networking/sql-migrate/sqlparse/*.go # gosub

--- a/scripts/sync-package-specs_linux-only
+++ b/scripts/sync-package-specs_linux-only
@@ -4,7 +4,7 @@ set -e
 
 # ensure gosub is installed (this will recompile it only if necessary)
 # go get github.com/vito/gosub
-go install github.com/vito/gosub
+go install github.com/vito/gosub@latest
 
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/src/service-discovery-controller/config/config.go
+++ b/src/service-discovery-controller/config/config.go
@@ -1,36 +1,49 @@
 package config
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/url"
 
 	"gopkg.in/validator.v2"
 )
 
 type Config struct {
-	Address                   string       `json:"address" validate:"nonzero"`
-	Port                      string       `json:"port" validate:"nonzero"`
-	Nats                      []NatsConfig `json:"nats"`
-	Index                     string       `json:"index"`
-	ServerCert                string       `json:"server_cert" validate:"nonzero"`
-	ServerKey                 string       `json:"server_key" validate:"nonzero"`
-	CACert                    string       `json:"ca_cert" validate:"nonzero"`
-	MetronPort                int          `json:"metron_port" validate:"min=1"`
-	LogLevelAddress           string       `json:"log_level_address"`
-	LogLevelPort              int          `json:"log_level_port"`
-	StalenessThresholdSeconds int          `json:"staleness_threshold_seconds" validate:"min=1"`
-	PruningIntervalSeconds    int          `json:"pruning_interval_seconds" validate:"min=1"`
-	MetricsEmitSeconds        int          `json:"metrics_emit_seconds" validate:"min=1"`
-	ResumePruningDelaySeconds int          `json:"resume_pruning_delay_seconds" validate:"min=0"`
-	WarmDurationSeconds       int          `json:"warm_duration_seconds" validate:"min=0"`
+	Address                   string     `json:"address" validate:"nonzero"`
+	Port                      string     `json:"port" validate:"nonzero"`
+	Nats                      NatsConfig `json:"nats"`
+	Index                     string     `json:"index"`
+	ServerCert                string     `json:"server_cert" validate:"nonzero"`
+	ServerKey                 string     `json:"server_key" validate:"nonzero"`
+	CACert                    string     `json:"ca_cert" validate:"nonzero"`
+	MetronPort                int        `json:"metron_port" validate:"min=1"`
+	LogLevelAddress           string     `json:"log_level_address"`
+	LogLevelPort              int        `json:"log_level_port"`
+	StalenessThresholdSeconds int        `json:"staleness_threshold_seconds" validate:"min=1"`
+	PruningIntervalSeconds    int        `json:"pruning_interval_seconds" validate:"min=1"`
+	MetricsEmitSeconds        int        `json:"metrics_emit_seconds" validate:"min=1"`
+	ResumePruningDelaySeconds int        `json:"resume_pruning_delay_seconds" validate:"min=0"`
+	WarmDurationSeconds       int        `json:"warm_duration_seconds" validate:"min=0"`
 }
 
 type NatsConfig struct {
-	Host string `json:"host"`
-	Port uint16 `json:"port"`
-	User string `json:"user"`
-	Pass string `json:"pass"`
+	Hosts                 []NatsHost      `json:"hosts"`
+	User                  string          `json:"user"`
+	Pass                  string          `json:"pass"`
+	TLSEnabled            bool            `json:"tls_enabled"`
+	CACerts               string          `json:"ca_certs"`
+	CAPool                *x509.CertPool  `json:"-"`
+	CertChain             string          `json:"cert_chain"`
+	PrivateKey            string          `json:"private_key"`
+	ClientAuthCertificate tls.Certificate `json:"-"`
+}
+
+type NatsHost struct {
+	Hostname string `json:"hostname"`
+	Port     uint16 `json:"port"`
 }
 
 func NewConfig(configJSON []byte) (*Config, error) {
@@ -43,21 +56,39 @@ func NewConfig(configJSON []byte) (*Config, error) {
 	if err = validator.Validate(sdcConfig); err != nil {
 		return nil, fmt.Errorf("invalid config: %s", err)
 	}
+
+	if sdcConfig.Nats.TLSEnabled {
+		certPool := x509.NewCertPool()
+		caCerts, err := ioutil.ReadFile(sdcConfig.Nats.CACerts)
+		if err != nil {
+			return nil, fmt.Errorf("error reading NATS CA certs: %w", err)
+		}
+		if ok := certPool.AppendCertsFromPEM(caCerts); !ok {
+			return nil, fmt.Errorf("unable to build NATS CA pool")
+		}
+		sdcConfig.Nats.CAPool = certPool
+
+		certificate, err := tls.LoadX509KeyPair(sdcConfig.Nats.CertChain, sdcConfig.Nats.PrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("error reading NATS mTLS client auth: %w", err)
+		}
+		sdcConfig.Nats.ClientAuthCertificate = certificate
+	}
+
 	return sdcConfig, err
 }
 
 func (c *Config) NatsServers() []string {
 	var natsServers []string
-	for _, info := range c.Nats {
-		uri :=
-			url.URL{
-				Scheme: "nats",
-				User:   url.UserPassword(info.User, info.Pass),
-				Host:   fmt.Sprintf("%s:%d", info.Host, info.Port),
-			}
+	for _, host := range c.Nats.Hosts {
+		uri := url.URL{
+			Scheme: "nats",
+			Host:   fmt.Sprintf("%s:%d", host.Hostname, host.Port),
+		}
+		if c.Nats.User != "" || c.Nats.Pass != "" {
+			uri.User = url.UserPassword(c.Nats.User, c.Nats.Pass)
+		}
 		natsServers = append(natsServers, uri.String())
-
 	}
-
 	return natsServers
 }

--- a/src/service-discovery-controller/mbus/nats_conn_provider.go
+++ b/src/service-discovery-controller/mbus/nats_conn_provider.go
@@ -1,11 +1,19 @@
 package mbus
 
-import "github.com/nats-io/go-nats"
+import (
+	"crypto/tls"
+
+	"github.com/nats-io/go-nats"
+)
 
 type NatsConnWithUrlProvider struct {
-	Url string
+	Url       string
+	TLSConfig *tls.Config
 }
 
 func (p *NatsConnWithUrlProvider) Connection(opts ...nats.Option) (NatsConn, error) {
+	if p.TLSConfig != nil {
+		opts = append(opts, nats.Secure(p.TLSConfig))
+	}
 	return nats.Connect(p.Url, opts...)
 }

--- a/src/service-discovery-controller/mbus/subscriber.go
+++ b/src/service-discovery-controller/mbus/subscriber.go
@@ -305,8 +305,8 @@ func (s *Subscriber) setupAddressMessageHandler() error {
 
 func (s *Subscriber) subscriptionOptionsJSON() []byte {
 	discoveryMessageJson, err := json.Marshal(ServiceDiscoveryStartMessage{
-		Id:   s.subOpts.ID,
-		Host: s.localIP,
+		Id:                               s.subOpts.ID,
+		Host:                             s.localIP,
 		MinimumRegisterIntervalInSeconds: s.subOpts.MinimumRegisterIntervalInSeconds,
 		PruneThresholdInSeconds:          s.subOpts.PruneThresholdInSeconds,
 	})

--- a/src/service-discovery-controller/service_discovery_controller_suite_test.go
+++ b/src/service-discovery-controller/service_discovery_controller_suite_test.go
@@ -1,6 +1,8 @@
 package main_test
 
 import (
+	"crypto/tls"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -33,8 +35,12 @@ var _ = SynchronizedAfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
 
-func RunNatsServerOnPort(port int) *server.Server {
+func RunNatsServerOnPort(port int, tlsConfig *tls.Config) *server.Server {
 	opts := gnatsd.DefaultTestOptions
 	opts.Port = port
+	if tlsConfig != nil {
+		opts.TLS = true
+		opts.TLSConfig = tlsConfig
+	}
 	return gnatsd.RunServer(&opts)
 }

--- a/src/test-helpers/tls_helpers.go
+++ b/src/test-helpers/tls_helpers.go
@@ -13,8 +13,9 @@ import (
 	"os"
 	"time"
 
-	. "github.com/onsi/gomega"
 	"net"
+
+	. "github.com/onsi/gomega"
 )
 
 func GenerateCaAndMutualTlsCerts() (caFileName string, certFileName string, privateKeyFileName string, cert tls.Certificate) {
@@ -126,7 +127,9 @@ func buildCertPem(privKey *rsa.PrivateKey, caFilePath string) (cert []byte, key 
 			Country:      []string{"USA"},
 			Organization: []string{"Cloud Foundry"},
 		},
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:    []string{"localhost"},
+
 		NotBefore:             now,
 		NotAfter:              notAfter,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
This PR adds support for service-discovery-controller to talk to NATS over mTLS. It also changes the main testsuite to test against TLS NATS.

This PR is part of https://github.com/cloudfoundry/cf-deployment/issues/929, where me and @ameowlia are trying to remove non-TLS NATS from `cf-deployment`