### PR TITLE
Quote groups identifier for compatibility with MySQL 8

### DIFF
--- a/scripts/docker-shell
+++ b/scripts/docker-shell
@@ -2,13 +2,14 @@
 set -e -u
 
 ROOT_DIR_PATH="$(cd $(dirname $0)/.. && pwd)"
-cd ${ROOT_DIR_PATH}
+cd "${ROOT_DIR_PATH}"
 
 db=${DB:-"postgres"} # if not set, default to postgres
 
-kernelversion="$(docker run -t -i alpine:latest uname -r | tr -d '\r\n' | tr -d '\-moby')"
 if [ "$db" = "mysql" ]; then
   docker_image=c2cnetworking/dev-mysql
+elif [ "$db" = "mysql8" ]; then
+  docker_image=c2cnetworking/dev-mysql8
 else
   docker_image=c2cnetworking/dev-postgres-ifb
 fi
@@ -17,8 +18,8 @@ docker run \
    --rm \
    -it \
    --privileged \
-   -v ${PWD}:/cf-networking-release \
-   -e DB=$db \
+   -v "${PWD}:/cf-networking-release" \
+   -e "DB=$db" \
    --cap-add ALL \
    -w /cf-networking-release \
    $docker_image \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -49,7 +49,7 @@ function bootDB {
   if [ "$db" = "postgres" ]; then
     launchDB="(docker-entrypoint.sh postgres &> /var/log/postgres-boot.log) &"
     testConnection="psql -h localhost -U postgres -c '\conninfo' &>/dev/null"
-  elif [ "$db" = "mysql" ]; then
+  elif [[ "$db" == "mysql"* ]]; then
     chown -R mysql:mysql /var/run/mysqld
     launchDB="(MYSQL_ROOT_PASSWORD=password /entrypoint.sh mysqld &> /var/log/mysql-boot.log) &"
     testConnection="echo '\s;' | mysql -h 127.0.0.1 -u root --password='password' &>/dev/null"

--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -18,7 +18,7 @@ go 1.16
 
 require (
 	code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed
-	code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5
+	code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348
 	code.cloudfoundry.org/clock v1.0.0
 	code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4
 	code.cloudfoundry.org/filelock v0.0.0-20180314203404-13cd41364639

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -5,6 +5,8 @@ code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed h1:lXyKwHvjX8AofvDk
 code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed/go.mod h1:XKlGVVXFi5EcHHMPzw3xgONK9PeEZuUbIC43XNwxD10=
 code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5 h1:2LNoWK64q5eJjFK1be1HoNeWh0tFZ4nGIz4YJmDvn00=
 code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5/go.mod h1:kf4WVsGZqWT4r9wA9xLpdc4U/QtB5HcUUMa1VSsb6AM=
+code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348 h1:6J54855savU7Iey5LA9AaevzV5JMnSCLR21piSeVjhw=
+code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348/go.mod h1:/3sxa/kc03LJnMR688nN/v1N7VDNzCbICOaNDdvS37s=
 code.cloudfoundry.org/clock v1.0.0 h1:kFXWQM4bxYvdBw2X8BbBeXwQNgfoWv1vqAk2ZZyBN2o=
 code.cloudfoundry.org/clock v1.0.0/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
 code.cloudfoundry.org/debugserver v0.0.0-20210608171006-d7658ce493f4 h1:6UIZEq5iyr4zDCgOH5MtRbgvsIjk4XFNUaaoMekEssQ=

--- a/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
@@ -101,7 +101,7 @@ func assertMigrationsSucceeded(conn *db.ConnWrapper, conf config.Config) {
 	Expect(migrationCount).To(Equal(numMigrations))
 
 	var groupCount int
-	conn.QueryRow("SELECT COUNT(*) FROM groups").Scan(&groupCount)
+	conn.QueryRow(`SELECT COUNT(*) FROM "groups"`).Scan(&groupCount)
 	Expect(groupCount).To(Equal(int(math.Exp2(float64(conf.TagLength*8))) - 1))
 }
 

--- a/src/code.cloudfoundry.org/policy-server/store/group.go
+++ b/src/code.cloudfoundry.org/policy-server/store/group.go
@@ -41,7 +41,7 @@ func (g *GroupTable) findRowByGUID(tx db.Transaction, guid, groupType string) (i
 	var id int
 	err := tx.QueryRow(
 		tx.Rebind(`
-		SELECT id FROM groups
+		SELECT id FROM "groups"
 		WHERE guid = ? AND type = ?
 		`),
 		guid,
@@ -53,7 +53,7 @@ func (g *GroupTable) findRowByGUID(tx db.Transaction, guid, groupType string) (i
 func (g *GroupTable) firstBlankRow(tx db.Transaction) (int, error) {
 	var id int
 	err := tx.QueryRow(
-		`SELECT id FROM groups
+		`SELECT id FROM "groups"
 		WHERE guid is NULL
 		ORDER BY id
 		LIMIT 1
@@ -65,7 +65,7 @@ func (g *GroupTable) firstBlankRow(tx db.Transaction) (int, error) {
 func (g *GroupTable) updateRow(tx db.Transaction, id int, guid, groupType string) error {
 	_, err := tx.Exec(
 		tx.Rebind(`
-			UPDATE groups SET guid = ?, type =  ?
+			UPDATE "groups" SET guid = ?, type =  ?
 			WHERE id = ?
 		`),
 		guid,
@@ -77,7 +77,7 @@ func (g *GroupTable) updateRow(tx db.Transaction, id int, guid, groupType string
 
 func (g *GroupTable) Delete(tx db.Transaction, id int) error {
 	_, err := tx.Exec(
-		tx.Rebind(`UPDATE groups SET guid = NULL, type = NULL WHERE id = ?`),
+		tx.Rebind(`UPDATE "groups" SET guid = NULL, type = NULL WHERE id = ?`),
 		id,
 	)
 	return err
@@ -86,7 +86,7 @@ func (g *GroupTable) Delete(tx db.Transaction, id int) error {
 func (g *GroupTable) GetID(tx db.Transaction, guid string) (int, error) {
 	var id int
 	err := tx.QueryRow(
-		tx.Rebind(`SELECT id FROM groups WHERE guid = ?`),
+		tx.Rebind(`SELECT id FROM "groups" WHERE guid = ?`),
 		guid,
 	).Scan(&id)
 

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
@@ -487,7 +487,7 @@ var _ = Describe("migrations", func() {
 					migrateTo("3a")
 
 					By("inserting existing data")
-					_, err := realDb.Exec(`insert into groups (guid) values ("some-guid")`)
+					_, err := realDb.Exec(`insert into "groups" (guid) values ('some-guid')`)
 					Expect(err).NotTo(HaveOccurred())
 
 					By("performing migration")
@@ -498,33 +498,33 @@ var _ = Describe("migrations", func() {
 					By("verifying existing rows have type 'app'")
 					rows, err := realDb.Query(`
 							SELECT count(*)
-							FROM groups
+							FROM "groups"
 							WHERE type = 'app' AND guid = 'some-guid'
 						`)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(scanCountRow(rows)).To(Equal(1))
 
 					By("inserting new data")
-					_, err = realDb.Exec(`insert into groups (guid) values ('some-new-guid')`)
+					_, err = realDb.Exec(`insert into "groups" (guid) values ('some-new-guid')`)
 					Expect(err).NotTo(HaveOccurred())
 
 					By("verifying new row defaults to type 'app'")
 					rows, err = realDb.Query(`
 							SELECT count(*)
-							FROM groups
+							FROM "groups"
 							WHERE type = 'app' AND guid = 'some-new-guid'
 						`)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(scanCountRow(rows)).To(Equal(1))
 
 					By("inserting new data with a type")
-					_, err = realDb.Exec(`insert into groups (guid, type) values ('some-new-guid-router', 'router')`)
+					_, err = realDb.Exec(`insert into "groups" (guid, type) values ('some-new-guid-router', 'router')`)
 					Expect(err).NotTo(HaveOccurred())
 
 					By("verifying new row has correct type")
 					rows, err = realDb.Query(`
 							SELECT count(*)
-							FROM groups
+							FROM "groups"
 							WHERE type = 'router' AND guid = 'some-new-guid-router'
 					`)
 					Expect(err).NotTo(HaveOccurred())
@@ -1683,15 +1683,15 @@ var _ = Describe("migrations", func() {
 				var srcGroupId, dstGroupId, dstId, policyId int64
 
 				By("inserting a src group")
-				_, err := realDb.Exec(`insert into groups (guid) values ('src-group-guid')`)
+				_, err := realDb.Exec(`insert into "groups" (guid) values ('src-group-guid')`)
 				Expect(err).NotTo(HaveOccurred())
-				err = realDb.QueryRow(`SELECT id FROM groups WHERE guid='src-group-guid'`).Scan(&srcGroupId)
+				err = realDb.QueryRow(`SELECT id FROM "groups" WHERE guid='src-group-guid'`).Scan(&srcGroupId)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("inserting a dst group")
-				_, err = realDb.Exec(`insert into groups (guid) values ('dst-group-guid')`)
+				_, err = realDb.Exec(`insert into "groups" (guid) values ('dst-group-guid')`)
 				Expect(err).NotTo(HaveOccurred())
-				err = realDb.QueryRow(`SELECT id FROM groups WHERE guid='dst-group-guid'`).Scan(&dstGroupId)
+				err = realDb.QueryRow(`SELECT id FROM "groups" WHERE guid='dst-group-guid'`).Scan(&dstGroupId)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("inserting a destination")

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0001.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0001.go
@@ -2,7 +2,7 @@ package migrations
 
 var migration_v0001 = map[string][]string{
 	"mysql": {
-		`CREATE TABLE IF NOT EXISTS groups (
+		`CREATE TABLE IF NOT EXISTS "groups" (
 		id int NOT NULL AUTO_INCREMENT,
 		guid varchar(255),
 		UNIQUE (guid),
@@ -10,7 +10,7 @@ var migration_v0001 = map[string][]string{
 	);`,
 		`CREATE TABLE IF NOT EXISTS destinations (
 		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES groups(id),
+		group_id int REFERENCES "groups"(id),
 		port int,
 		protocol varchar(255),
 		UNIQUE (group_id, port, protocol),
@@ -18,7 +18,7 @@ var migration_v0001 = map[string][]string{
 	);`,
 		`CREATE TABLE IF NOT EXISTS policies (
 		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES groups(id),
+		group_id int REFERENCES "groups"(id),
 		destination_id int REFERENCES destinations(id),
 		UNIQUE (group_id, destination_id),
 		PRIMARY KEY (id)
@@ -48,7 +48,7 @@ var migration_v0001 = map[string][]string{
 
 var migration_modified_v0001 = map[string][]string{
 	"mysql": {
-		`CREATE TABLE IF NOT EXISTS groups (
+		`CREATE TABLE IF NOT EXISTS "groups" (
 		id int NOT NULL AUTO_INCREMENT,
 		guid varchar(255),
 		UNIQUE (guid),
@@ -68,7 +68,7 @@ var migration_modified_v0001a = map[string][]string{
 	"mysql": {
 		`CREATE TABLE IF NOT EXISTS destinations (
 		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES groups(id),
+		group_id int REFERENCES "groups"(id),
 		port int,
 		protocol varchar(255),
 		UNIQUE (group_id, port, protocol),
@@ -90,7 +90,7 @@ var migration_modified_v0001b = map[string][]string{
 	"mysql": {
 		`CREATE TABLE IF NOT EXISTS policies (
 		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES groups(id),
+		group_id int REFERENCES "groups"(id),
 		destination_id int REFERENCES destinations(id),
 		UNIQUE (group_id, destination_id),
 		PRIMARY KEY (id)

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0003.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0003.go
@@ -2,8 +2,8 @@ package migrations
 
 var migration_v0003 = map[string][]string{
 	"mysql": {
-		`ALTER TABLE groups ADD COLUMN type varchar(255) DEFAULT 'app'`,
-		`CREATE INDEX idx_type ON groups (type)`,
+		`ALTER TABLE "groups" ADD COLUMN type varchar(255) DEFAULT 'app'`,
+		`CREATE INDEX idx_type ON "groups" (type)`,
 	},
 
 	"postgres": {
@@ -14,7 +14,7 @@ var migration_v0003 = map[string][]string{
 
 var migration_modified_v0003 = map[string][]string{
 	"mysql": {
-		`ALTER TABLE groups ADD COLUMN type varchar(255) DEFAULT 'app'`,
+		`ALTER TABLE "groups" ADD COLUMN type varchar(255) DEFAULT 'app'`,
 	},
 
 	"postgres": {
@@ -24,7 +24,7 @@ var migration_modified_v0003 = map[string][]string{
 
 var migration_modified_v0003a = map[string][]string{
 	"mysql": {
-		`CREATE INDEX idx_type ON groups (type)`,
+		`CREATE INDEX idx_type ON "groups" (type)`,
 	},
 
 	"postgres": {

--- a/src/code.cloudfoundry.org/policy-server/store/store.go
+++ b/src/code.cloudfoundry.org/policy-server/store/store.go
@@ -290,9 +290,9 @@ func (s *store) ByGuids(srcGuids, destGuids []string, inSourceAndDest bool) ([]P
 			destinations.end_port,
 			destinations.protocol
 		from policies
-		left outer join groups as src_grp on (policies.group_id = src_grp.id)
+		left outer join "groups" as src_grp on (policies.group_id = src_grp.id)
 		left outer join destinations on (destinations.id = policies.destination_id)
-		left outer join groups as dst_grp on (destinations.group_id = dst_grp.id)`
+		left outer join "groups" as dst_grp on (destinations.group_id = dst_grp.id)`
 
 	if len(wheres) > 0 {
 		andOr := " OR "
@@ -327,9 +327,9 @@ func (s *store) All() ([]Policy, error) {
 			destinations.end_port,
 			destinations.protocol
 		from policies
-		left outer join groups as src_grp on (policies.group_id = src_grp.id)
+		left outer join "groups" as src_grp on (policies.group_id = src_grp.id)
 		left outer join destinations on (destinations.id = policies.destination_id)
-		left outer join groups as dst_grp on (destinations.group_id = dst_grp.id);`)
+		left outer join "groups" as dst_grp on (destinations.group_id = dst_grp.id);`)
 }
 
 func (s *store) tagIntToString(tag int) string {

--- a/src/code.cloudfoundry.org/policy-server/store/store_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/store_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Store", func() {
 
 				Expect(err).To(MatchError("creating destination: some-insert-error"))
 				var groupsCount int
-				err = realDb.QueryRow(`SELECT count(*) FROM groups WHERE guid IS NOT NULL`).Scan(&groupsCount)
+				err = realDb.QueryRow(`SELECT count(*) FROM "groups" WHERE guid IS NOT NULL`).Scan(&groupsCount)
 				Expect(groupsCount).To(BeZero())
 			})
 		})

--- a/src/code.cloudfoundry.org/policy-server/store/tag_populator.go
+++ b/src/code.cloudfoundry.org/policy-server/store/tag_populator.go
@@ -12,7 +12,8 @@ type TagPopulator struct {
 
 func (t *TagPopulator) PopulateTables(tl int) error {
 	var err error
-	row := t.DBConnection.QueryRow(`SELECT COUNT(*) FROM groups`)
+
+	row := t.DBConnection.QueryRow(`SELECT COUNT(*) FROM "groups"`)
 	if row != nil {
 		var count int
 		err = row.Scan(&count)
@@ -25,7 +26,7 @@ func (t *TagPopulator) PopulateTables(tl int) error {
 	}
 
 	var b bytes.Buffer
-	_, err = b.WriteString("INSERT INTO groups (guid) VALUES (NULL)")
+	_, err = b.WriteString(`INSERT INTO "groups" (guid) VALUES (NULL)`)
 	if err != nil {
 		return err
 	}

--- a/src/code.cloudfoundry.org/policy-server/store/tag_populator_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/tag_populator_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Tag Populator", func() {
 			It("does not exceed 2^(tag_length * 8) rows", func() {
 				tagPopulator.PopulateTables(1)
 				var id int
-				err := realDb.QueryRow(`SELECT id FROM groups ORDER BY id DESC LIMIT 1`).Scan(&id)
+				err := realDb.QueryRow(`SELECT id FROM "groups" ORDER BY id DESC LIMIT 1`).Scan(&id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(255))
 			})
@@ -68,14 +68,14 @@ var _ = Describe("Tag Populator", func() {
 			It("does not add more rows", func() {
 				tagPopulator.PopulateTables(1)
 				var id int
-				err := realDb.QueryRow(`SELECT id FROM groups ORDER BY id DESC LIMIT 1`).Scan(&id)
+				err := realDb.QueryRow(`SELECT id FROM "groups" ORDER BY id DESC LIMIT 1`).Scan(&id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(255))
 
 				tagPopulator.PopulateTables(2)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = realDb.QueryRow(`SELECT id FROM groups ORDER BY id DESC LIMIT 1`).Scan(&id)
+				err = realDb.QueryRow(`SELECT id FROM "groups" ORDER BY id DESC LIMIT 1`).Scan(&id)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal(255))
 			})

--- a/src/code.cloudfoundry.org/policy-server/store/tag_store.go
+++ b/src/code.cloudfoundry.org/policy-server/store/tag_store.go
@@ -53,7 +53,7 @@ func (s *tagStore) Tags() ([]Tag, error) {
 	var tags []Tag
 
 	rows, err := s.conn.Query(`
-		SELECT guid, id, type FROM groups
+		SELECT guid, id, type FROM "groups"
 		WHERE guid IS NOT NULL
 		ORDER BY id
 	`)

--- a/src/code.cloudfoundry.org/policy-server/store/tag_store_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/tag_store_test.go
@@ -210,7 +210,7 @@ var _ = Describe("TagStore", func() {
 
 			BeforeEach(func() {
 				var err error
-				rows, err = realDb.Query(`select id from groups`)
+				rows, err = realDb.Query(`select id from "groups"`)
 				Expect(err).NotTo(HaveOccurred())
 
 				mockDb.QueryReturns(rows, nil)

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/db/connection_pool.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/db/connection_pool.go
@@ -31,7 +31,7 @@ func NewConnectionPool(conf Config,
 	connectionPool.SetMaxOpenConns(maxOpenConnections)
 	connectionPool.SetMaxIdleConns(maxIdleConnections)
 	connectionPool.SetConnMaxLifetime(connMaxLifetime)
-	logger.Info("db connection retrived", lager.Data{})
+	logger.Info("db connection retrieved", lager.Data{})
 
 	return connectionPool, nil
 }

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/db/mysql_connection_string_builder.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/db/mysql_connection_string_builder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -21,7 +22,8 @@ type MySQLConnectionStringBuilder struct {
 }
 
 func (m *MySQLConnectionStringBuilder) Build(config Config) (string, error) {
-	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", config.User, config.Password, config.Host, config.Port, config.DatabaseName)
+	sqlMode := url.QueryEscape("(SELECT CONCAT(@@sql_mode,',ANSI_QUOTES'))")
+	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&sql_mode=%s", config.User, config.Password, config.Host, config.Port, config.DatabaseName, sqlMode)
 
 	dbConfig, err := m.MySQLAdapter.ParseDSN(connString)
 	if err != nil {

--- a/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/testsupport/db.go
+++ b/src/code.cloudfoundry.org/vendor/code.cloudfoundry.org/cf-networking-helpers/testsupport/db.go
@@ -122,8 +122,6 @@ func getMySQLDBConfig() db.Config {
 	}
 	port, _ := strconv.Atoi(portStr)
 
-	fmt.Printf("User %s , Password %s , host %s , port %d\n", user, password, host, port)
-
 	return db.Config{
 		Type:     "mysql",
 		User:     user,

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -1,7 +1,7 @@
 # code.cloudfoundry.org/bbs v0.0.0-20210727125654-2ad50317f7ed
 ## explicit
 code.cloudfoundry.org/bbs/db/sqldb/helpers/monitor
-# code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210825141236-777da71209d5
+# code.cloudfoundry.org/cf-networking-helpers v0.0.0-20210929193536-efcc04207348
 ## explicit
 code.cloudfoundry.org/cf-networking-helpers/db
 code.cloudfoundry.org/cf-networking-helpers/db/fakes


### PR DESCRIPTION
The network policy server has a `groups` table - this is now a reserved word in MySQL 8:
https://dev.mysql.com/doc/refman/8.0/en/keywords.html

We are not intending to rename the `groups` table at this stage. This PR quotes references to the table to avoid erroring against MySQL 8.

It also bumps cf-networking-helpers to add `ANSI_QUOTES` to the `sql_mode` for new MySQL connections so that we can use the same quoting syntax for both MySQL and PostgreSQL

CC @geofffranks @cphi-vmw