### PR TITLE
Fix FDescribe issue in conn limit test

### DIFF
--- a/src/code.cloudfoundry.org/test/acceptance/outbound_conn_limit_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/outbound_conn_limit_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Outbound connection limit", func() {
 		Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
 	})
 
-	FDescribe("when an app opens multiple connections to one host", func() {
+	Describe("when an app opens multiple connections to one host", func() {
 		It("the connections get rate limited", func() {
 			By("pushing proxy")
 			pushProxy(proxyName)


### PR DESCRIPTION
Fixes a stupid clumsy in the acceptance tests introduced with https://github.com/cloudfoundry/silk-release/issues/30.