### PR TITLE
Removed unused golang-1-linux package

### DIFF
--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1-linux
-fingerprint: 5b79dae188e2d5d5f7dde7df37bf9e4b6d93f798c40a18f3ed76bf7500b8a333


### PR DESCRIPTION
- We pinned to Go 1.16 temporarily in c731a0ee, switching to the golang-1.16-linux package
- Delete the golang-1-linux package to avoid bloating the release with an unused dependency