### PR TITLE
Fix testing scripts to run in docker with DB setup

### DIFF
--- a/scripts/docker-shell
+++ b/scripts/docker-shell
@@ -4,7 +4,7 @@ set -e -u
 ROOT_DIR_PATH="$(cd $(dirname $0)/.. && pwd)"
 cd "${ROOT_DIR_PATH}"
 
-db=${DB:-"postgres"} # if not set, default to postgres
+db=${DB:-"mysql"} # if not set, default to mysql
 
 if [ "$db" = "mysql" ]; then
   docker_image=c2cnetworking/dev-mysql

--- a/scripts/docker-shell-with-started-db
+++ b/scripts/docker-shell-with-started-db
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e -u
+
+SCRIPT_PATH="$(cd "$(dirname "${0}")" && pwd)"
+"${SCRIPT_PATH}/docker-shell" /cf-networking-release/scripts/start-db-in-docker.sh

--- a/scripts/start-db-helper
+++ b/scripts/start-db-helper
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function loadIFB {
+  set +e
+    depmod "$(uname -r)"
+    modprobe ifb
+  set -e
+}
+
+function bootDB {
+  db="$1"
+
+  if [ "${db}" = "postgres" ]; then
+    launchDB="(docker-entrypoint.sh postgres &> /var/log/postgres-boot.log) &"
+    testConnection="psql -h localhost -U postgres -c '\conninfo'"
+  elif [[ "${db}" == "mysql"* ]]; then
+    launchDB="(MYSQL_ROOT_PASSWORD=password /entrypoint.sh mysqld &> /var/log/mysql-boot.log) &"
+    testConnection="mysql -h localhost -u root -D mysql -e '\s;' --password='password'"
+  else
+    echo "skipping database"
+    return 0
+  fi
+
+  echo -n "booting ${db}"
+  eval "$launchDB"
+  for _ in $(seq 1 60); do
+    if eval "${testConnection}" &> /dev/null; then
+      echo "connection established to ${db}"
+      return 0
+    fi
+    echo -n "."
+    sleep 1
+  done
+  eval "${testConnection}" || true
+  echo "unable to connect to ${db}"
+  exit 1
+}

--- a/scripts/start-db-in-docker.sh
+++ b/scripts/start-db-in-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -u
+
+SCRIPT_PATH="$(cd "$(dirname "${0}")" && pwd)"
+. "${SCRIPT_PATH}/start-db-helper"
+
+cd /cf-networking-release
+export GOPATH=$PWD
+
+
+loadIFB
+bootDB "${DB:-"notset"}"
+set +e
+exec /bin/bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
-set -e -u -x
+specified_package="${1}"
 
-SCRIPT_PATH="$(cd "$(dirname $0)" && pwd)"
+set -e -u
 
-cd ${SCRIPT_PATH}/..
+DB="${DB:-"notset"}"
 
-SERIAL_NODES="${SERIAL_NODES:-1}"
+SCRIPT_PATH="$(cd "$(dirname "${0}")" && pwd)"
+. "${SCRIPT_PATH}/start-db-helper"
+
+cd "${SCRIPT_PATH}/.."
+
+serial_nodes=1
+if [[ "${DB}" == "postgres" ]]; then
+  serial_nodes=4
+fi
 
 declare -a serial_packages=(
   "src/code.cloudfoundry.org/policy-server/integration/timeouts"
@@ -17,113 +25,83 @@ declare -a serial_packages=(
 
 # smoke/perf/acceptance/scaling tests should be skipped
 declare -a ignored_packages=(
-  "src/code.cloudfoundry.org/test"
+  "src/code.cloudfoundry.org/test/.*"
 )
 
 for pkg in $(echo "${exclude_packages:-""}" | jq -r .[]); do
   ignored_packages+=("${pkg}")
 done
 
-function loadIFB {
-  set +e
-    depmod $(uname -r)
-    modprobe ifb
-  set -e
+contains_element() {
+  local e match="${1}"
+  shift
+  for e; do [[ "${e}" == "${match}" ]] && return 0; done
+  return 1
 }
 
-function bootDB {
-  db=$1
-
-  if [ "$db" = "random" ]; then
-    cointoss=$RANDOM
-    set +e
-    let "cointoss %= 2"
-    set -e
-    if [ "$cointoss" == "0" ]; then
-      db="postgres"
-    else
-      db="mysql"
-    fi
-  fi
-
-  if [ "$db" = "postgres" ]; then
-    launchDB="(docker-entrypoint.sh postgres &> /var/log/postgres-boot.log) &"
-    testConnection="psql -h localhost -U postgres -c '\conninfo' &>/dev/null"
-  elif [[ "$db" == "mysql"* ]]; then
-    chown -R mysql:mysql /var/run/mysqld
-    launchDB="(MYSQL_ROOT_PASSWORD=password /entrypoint.sh mysqld &> /var/log/mysql-boot.log) &"
-    testConnection="echo '\s;' | mysql -h 127.0.0.1 -u root --password='password' &>/dev/null"
-  else
-    echo "skipping database"
-    return 0
-  fi
-
-  echo -n "booting $db"
-  eval "$launchDB"
-  for _ in $(seq 1 60); do
-    set +e
-    eval "${testConnection}"
-    exitcode=$?
-    set -e
-    if [ ${exitcode} -eq 0 ]; then
-      echo "connection established to $db"
-      return 0
-    fi
-    echo -n "."
-    sleep 1
-  done
-  echo "unable to connect to $db"
-  exit 1
+test_package() {
+  local package=$1
+  shift
+  pushd "${package}" &>/dev/null
+  ginkgo --race -randomizeAllSpecs -randomizeSuites -failFast \
+      -ldflags="extldflags=-WL,--allow-multiple-definition" \
+       "${@}";
+  rc=$?
+  popd &>/dev/null
+  return "${rc}"
 }
 
 loadIFB
-bootDB "${DB:-"notset"}"
+bootDB "${DB}"
 
 declare -a packages
 if [[ -n "${include_only:-""}" ]]; then
-  mapfile -t packages < <(jq -r .[]) <<< "${include_only}"
+  mapfile -t packages < <(jq -r .[] <<< "${include_only}")
 else
-  packages=($(find src -type f -name "*_test.go" | xargs -L 1 -I{} dirname {} | sort -u))
+  mapfile -t packages < <(find src -type f -name '*_test.go' -print0 | xargs -0 -L 1 -I{} dirname {} | sort -u)
 fi
 
 # filter out serial_packages from packages
-for i in "${serial_packages[@]}"; do
-  packages=(${packages[@]//*$i*})
+for serial_pkg in "${serial_packages[@]}"; do
+    for i in "${!packages[@]}"; do
+      if [[ "${packages["${i}"]}" == "${serial_pkg}" ]]; then
+        unset "packages[${i}]"
+      fi
+    done
 done
 
 # filter out explicitly ignored packages
-for i in "${ignored_packages[@]}"; do
-  packages=(${packages[@]//*$i*})
-  serial_packages=(${serial_packages[@]//*$i*})
-done
-
-if [ "${1:-""}" = "" ]; then
-  for dir in "${packages[@]}"; do
-    pushd "$dir"
-      ginkgo -p --race -randomizeAllSpecs -randomizeSuites \
-        -ldflags="-extldflags=-Wl,--allow-multiple-definition" \
-        ${@:2}
-    popd
-  done
-  for dir in "${serial_packages[@]}"; do
-    pushd "$dir"
-      ginkgo --nodes "${SERIAL_NODES}" --race -randomizeAllSpecs -randomizeSuites -failFast \
-        -ldflags="-extldflags=-Wl,--allow-multiple-definition" \
-        ${@:2}
-    popd
-  done
-else
-  dir="${@: -1}"
-  dir="${dir#./}"
-  for package in "${serial_packages[@]}"; do
-    if [[ "${dir##$package}" != "${dir}" ]]; then
-      ginkgo --race -randomizeAllSpecs -randomizeSuites -failFast \
-        -ldflags="-extldflags=-Wl,--allow-multiple-definition" \
-        "${@}"
-      exit $?
+for ignored_pkg in "${ignored_packages[@]}"; do
+  for i in "${!packages[@]}"; do
+    if [[ "${packages["${i}"]}" =~ ^${ignored_pkg}$ ]]; then
+      unset "packages[${i}]"
     fi
   done
-  ginkgo -p --race -randomizeAllSpecs -randomizeSuites -failFast \
-    -ldflags="-extldflags=-Wl,--allow-multiple-definition" \
-    "${@}"
+  for i in "${!serial_packages[@]}"; do
+    if [[ "${serial_packages["${i}"]}" =~ ^${ignored_pkg}$ ]]; then
+      unset "serial_packages[${i}]"
+    fi
+  done
+done
+
+if [[ -z "${specified_package}" ]]; then
+  echo "testing packages: " "${packages[@]}"
+  for dir in "${packages[@]}"; do
+    echo testing "${dir}"
+    test_package "${dir}" -p
+  done
+  echo "testing serial packages: " "${serial_packages[@]}"
+  for dir in "${serial_packages[@]}"; do
+    echo testing "${dir}"
+    test_package "${dir}" --nodes "${serial_nodes}"
+  done
+else
+  specified_package="${specified_package#./}"
+  if contains_element "${specified_package}" "${serial_packages[@]}"; then
+    echo "testing serial package ${specified_package}"
+    test_package "${specified_package}" --nodes "${serial_nodes}"
+  else
+    echo "testing package ${specified_package}"
+    test_package "${specified_package}" -p
+  fi
 fi


### PR DESCRIPTION
- Recreated the docker-shell-with-started-db and start-db-in-docker.sh
  scripts
- Updated scripts/test.sh to function post go-mod conversion when
  individual packages were specified for testing
- Updated the default DB for docker-shell / docker-shell-with-started-db
  to be mysql now.