### PR TITLE
Update ASGs with the minimal table lock time

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/store/security_groups_store.go
+++ b/src/code.cloudfoundry.org/policy-server/store/security_groups_store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -9,8 +10,8 @@ import (
 
 //counterfeiter:generate -o fakes/security_groups_store.go --fake-name SecurityGroupsStore . SecurityGroupsStore
 type SecurityGroupsStore interface {
-	Replace([]SecurityGroup) error
 	BySpaceGuids([]string, Page) ([]SecurityGroup, Pagination, error)
+	Replace([]SecurityGroup) error
 }
 
 type SGStore struct {
@@ -95,71 +96,111 @@ func (sgs *SGStore) BySpaceGuids(spaceGuids []string, page Page) ([]SecurityGrou
 	return result, Pagination{Next: nextId}, nil
 }
 
+/*
+The Replace function replaces the security_group table with new data via the
+following algorithm:
+ 1. make a map of all guids and ids of the current security groups
+ 2. make a temporary table called security_group_tmp
+ 3. fill in security_group_tmp table with newSecurityGroups, plus matching
+ ids from security_group table
+ 4. rename the tables
+	4a. security_groups --> security_groups_old
+	4b. security_groups_tmp --> security_groups
+ 5. Drop the security_group_old table
+
+This algorithm ensures that ids are kept the same, which is required because
+policy-agent uses ids for pagination.
+*/
 func (sgs *SGStore) Replace(newSecurityGroups []SecurityGroup) error {
+	guidsToIds, err := sgs.securityGroupGuidsToIds()
+	if err != nil {
+		return fmt.Errorf("getting security groups: %s", err)
+	}
+
 	tx, err := sgs.Conn.Beginx()
 	if err != nil {
 		return fmt.Errorf("create transaction: %s", err)
 	}
 	defer tx.Rollback()
 
-	existingGuids := map[string]bool{}
-	rows, err := tx.Queryx("SELECT guid FROM security_groups")
+	_, err = tx.Exec(sgs.createTmpTableQuery())
 	if err != nil {
-		return fmt.Errorf("selecting security groups: %s", err)
+		return fmt.Errorf("creating security_groups_tmp table: %s", err)
 	}
-	if rows != nil {
-		defer rows.Close()
-		for rows.Next() {
-			var guid string
-			err := rows.Scan(&guid)
+
+	if sgs.Conn.DriverName() == helpers.MySQL {
+		var maxId sql.NullInt64
+		rows := tx.QueryRow("SELECT MAX(id) FROM security_groups")
+		err = rows.Scan(&maxId)
+		if err != nil {
+			return fmt.Errorf("getting max id: %s", err)
+		}
+		if maxId.Valid {
+			// Rebind does not work with auto_increment, we can trust id value
+			_, err = tx.Exec(fmt.Sprintf(`ALTER TABLE security_groups_tmp AUTO_INCREMENT = %d`, maxId.Int64+1))
 			if err != nil {
-				return fmt.Errorf("scanning security group result: %s", err)
+				return fmt.Errorf("setting auto_increment: %s", err)
 			}
-			existingGuids[guid] = true
 		}
 	}
 
-	upsertQuery := tx.Rebind(`
-		INSERT INTO security_groups
+	insertQuery := tx.Rebind(`
+		INSERT INTO security_groups_tmp
 		(guid, name, rules, staging_default, running_default, staging_spaces, running_spaces)
-		VALUES(?, ?, ?, ?, ?, ?, ?) ` +
-		sgs.onConflictUpdateSQL() +
-		` name=?, rules=?, staging_default=?, running_default=?, staging_spaces=?, running_spaces=?`)
+		VALUES(?, ?, ?, ?, ?, ?, ?)`)
+
+	insertWithIdQuery := tx.Rebind(`
+		INSERT INTO security_groups_tmp
+		(id, guid, name, rules, staging_default, running_default, staging_spaces, running_spaces)
+		VALUES(?, ?, ?, ?, ?, ?, ?, ?)`)
 
 	for _, group := range newSecurityGroups {
-		delete(existingGuids, group.Guid)
+		id, found := guidsToIds[group.Guid]
+		if found {
+			_, err = tx.Exec(insertWithIdQuery,
+				id,
+				group.Guid,
+				group.Name,
+				group.Rules,
+				group.StagingDefault,
+				group.RunningDefault,
+				group.StagingSpaceGuids,
+				group.RunningSpaceGuids,
+			)
 
-		_, err := tx.Exec(upsertQuery,
-			group.Guid,
-			group.Name,
-			group.Rules,
-			group.StagingDefault,
-			group.RunningDefault,
-			group.StagingSpaceGuids,
-			group.RunningSpaceGuids,
-			group.Name,
-			group.Rules,
-			group.StagingDefault,
-			group.RunningDefault,
-			group.StagingSpaceGuids,
-			group.RunningSpaceGuids,
-		)
+		} else {
+			_, err = tx.Exec(insertQuery,
+				group.Guid,
+				group.Name,
+				group.Rules,
+				group.StagingDefault,
+				group.RunningDefault,
+				group.StagingSpaceGuids,
+				group.RunningSpaceGuids,
+			)
+		}
 		if err != nil {
 			return fmt.Errorf("saving security group %s (%s): %s", group.Guid, group.Name, err)
 		}
 	}
 
-	if len(existingGuids) > 0 {
-		guids := []interface{}{}
-		for guid := range existingGuids {
-			guids = append(guids, guid)
-		}
-		_, err = tx.Exec(tx.Rebind(`
-			DELETE FROM security_groups WHERE guid IN (`+helpers.QuestionMarks(len(existingGuids))+`)`),
-			guids...)
+	for _, query := range sgs.swapTablesQueries("security_groups", "security_groups_tmp", "security_groups_old") {
+		_, err = tx.Exec(query)
 		if err != nil {
-			return fmt.Errorf("deleting security groups: %s", err)
+			return fmt.Errorf("swapping security_groups_tmp and security_groups: %s", err)
 		}
+	}
+
+	if sgs.Conn.DriverName() == helpers.Postgres {
+		_, err = tx.Exec("ALTER SEQUENCE security_groups_id_seq OWNED BY security_groups.id")
+		if err != nil {
+			return fmt.Errorf("changing seq owner: %s", err)
+		}
+	}
+
+	_, err = tx.Exec("DROP TABLE security_groups_old")
+	if err != nil {
+		return fmt.Errorf("dropping security_groups_old table: %s", err)
 	}
 
 	err = tx.Commit()
@@ -167,6 +208,28 @@ func (sgs *SGStore) Replace(newSecurityGroups []SecurityGroup) error {
 		return fmt.Errorf("committing transaction: %s", err)
 	}
 	return nil
+}
+
+func (sgs *SGStore) securityGroupGuidsToIds() (map[string]int, error) {
+	rows, err := sgs.Conn.Query(`SELECT id, guid FROM security_groups`)
+	if err != nil {
+		return nil, fmt.Errorf("selecting security groups: %s", err)
+	}
+	defer rows.Close()
+
+	result := map[string]int{}
+	var id int
+	var guid string
+
+	for rows.Next() {
+		err := rows.Scan(&id, &guid)
+		if err != nil {
+			return nil, fmt.Errorf("scanning security group result: %s", err)
+		}
+		result[guid] = id
+	}
+
+	return result, nil
 }
 
 func (sgs *SGStore) jsonOverlapsSQL(columnName string, filterValues []string) string {
@@ -185,12 +248,28 @@ func (sgs *SGStore) jsonOverlapsSQL(columnName string, filterValues []string) st
 	}
 }
 
-func (sgs *SGStore) onConflictUpdateSQL() string {
+func (sgs *SGStore) swapTablesQueries(currentTableName, tempTableName, oldTableName string) []string {
 	switch sgs.Conn.DriverName() {
 	case helpers.MySQL:
-		return "ON DUPLICATE KEY UPDATE"
+		return []string{
+			"RENAME TABLE " + currentTableName + " TO " + oldTableName + ", " + tempTableName + " TO " + currentTableName,
+		}
 	case helpers.Postgres:
-		return "ON CONFLICT (guid) DO UPDATE SET"
+		return []string{
+			"ALTER TABLE " + currentTableName + " RENAME TO " + oldTableName,
+			"ALTER TABLE " + tempTableName + " RENAME TO " + currentTableName,
+		}
+	default:
+		return []string{""}
+	}
+}
+
+func (sgs *SGStore) createTmpTableQuery() string {
+	switch sgs.Conn.DriverName() {
+	case helpers.MySQL:
+		return "CREATE TABLE security_groups_tmp LIKE security_groups"
+	case helpers.Postgres:
+		return "CREATE TABLE security_groups_tmp (LIKE security_groups INCLUDING ALL)"
 	default:
 		return ""
 	}


### PR DESCRIPTION
We are creating a temporary table that we populate with data and then rename the tables in transaction to minimize transaction lock time on ASGs so that policy agent can poll it without downtime when starting applications.