### PR TITLE
Add HSTS header to policy-server-internal

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/integration/internal_api_policies_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/internal_api_policies_test.go
@@ -257,6 +257,18 @@ var _ = Describe("Internal Policies API", func() {
 				ContainElement(HaveOriginAndName("policy-server-internal", "DBQueryDurationMax")),
 			)
 		})
+
+		It("adds a Strict-Transport-Security header", func() {
+			resp := helpers.MakeAndDoHTTPSRequest(
+				"GET",
+				fmt.Sprintf("https://%s:%d/networking/v1/internal/policies", internalConf.ListenHost, internalConf.InternalListenPort),
+				nil,
+				tlsConfig,
+			)
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(resp.Header.Get("Strict-Transport-Security")).To(Equal("max-age=31536000"))
+		})
 	})
 
 	Describe("health", func() {


### PR DESCRIPTION
- The inclusion of the HSTS header for the external policy server has
  been around since be6079dd84f4a4e6fee34b7778e5be9c2d869894
- This commit adds the X-Strict-Transport-Security header to the
  internal policy server

[#181483084](https://www.pivotaltracker.com/story/show/181483084)