### PR TITLE
Add setup for Dynamic ASG performance testing

### DIFF
--- a/src/code.cloudfoundry.org/cf-pusher/cmd/multispace-pusher/main.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cmd/multispace-pusher/main.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"code.cloudfoundry.org/cf-pusher/cf_cli_adapter"
+	"code.cloudfoundry.org/cf-pusher/cf_command"
+	"code.cloudfoundry.org/cf-pusher/config"
+	"code.cloudfoundry.org/cf-pusher/manifest_generator"
+	"code.cloudfoundry.org/cf-pusher/models"
+	"code.cloudfoundry.org/lib/testsupport"
+)
+
+type Config struct {
+	config.Config
+	GlobalAGGs        int `json:"global_asgs"`
+	TotalSpaces       int `json:"total_spaces"`
+	SpacesWithOneASG  int `json:"spaces_with_one_asg"`
+	HowManyASGsIsMany int `json:"how_many_asgs_is_many"`
+	AppsPerSpace      int `json:"apps_per_space"`
+}
+
+type ConcurrentSpaceSetup struct {
+	Adapter         *cf_cli_adapter.Adapter
+	ApiConnector    cf_command.ApiConnector
+	OrgSpaceCreator cf_command.OrgSpaceCreator
+	AppPusher       cf_command.AppPusher
+}
+
+func main() {
+	config := parseConfig()
+
+	globalAdapter := generateAdapterWithHome(config.Prefix)
+	globalApiConnector := &cf_command.ApiConnector{
+		Api:               config.Api,
+		AdminUser:         config.AdminUser,
+		AdminPassword:     config.AdminPassword,
+		SkipSSLValidation: config.SkipSSLValidation,
+		Adapter:           globalAdapter,
+	}
+	if err := globalApiConnector.Connect(); err != nil {
+		log.Fatalf("connecting to api: %s", err)
+	}
+
+	// Create global asgs
+	createGlobalASGs(config)
+	// Create a bunch of bindable ASGs
+	manyASGs := createManyASGs(config.HowManyASGsIsMany, config.ASGSize, config.Prefix, globalAdapter)
+	// Compile the proxy app
+	compileBinary()
+
+	// Iterate over each space and create/bind asgs and push apps as needed
+	sem := make(chan bool, config.Concurrency)
+	for i := 0; i < config.TotalSpaces; i++ {
+		setup := generateConcurrentSpaceSetup(i, config)
+		sem <- true
+		go func(s *ConcurrentSpaceSetup, c Config, index int) {
+			defer func() { <-sem }()
+
+			// Connect to the api with this adapter
+			if err := s.ApiConnector.Connect(); err != nil {
+				log.Fatalf("connecting to api: %s", err)
+			}
+
+			// Create and target the space
+			if err := s.OrgSpaceCreator.Create(); err != nil {
+				log.Fatalf("creating org and space: %s", err)
+			}
+
+			if index < c.SpacesWithOneASG {
+				// Create and bind a single ASG to this space
+				createAndBindOneASGToThisSpace(fmt.Sprintf("%s-asg", s.OrgSpaceCreator.Space), c.ASGSize, s.OrgSpaceCreator, s.Adapter)
+			} else {
+				// Bind many asgs to this space
+				bindManyASGsToThisSpace(manyASGs, s.OrgSpaceCreator.Org, s.OrgSpaceCreator.Space, s.Adapter)
+			}
+
+			// Push apps for this space
+			if err := s.AppPusher.Push(); err != nil {
+				log.Printf("Got an error while pushing proxy apps: %s", err)
+			}
+
+		}(setup, config, i)
+	}
+
+	for i := 0; i < cap(sem); i++ {
+		sem <- true
+	}
+}
+
+func generateConcurrentSpaceSetup(spaceNumber int, config Config) *ConcurrentSpaceSetup {
+	appsDir := os.Getenv("APPS_DIR")
+	if appsDir == "" {
+		log.Fatal("APPS_DIR not set")
+	}
+	orgName := fmt.Sprintf("%s-org", config.Prefix)
+	adapter := generateAdapterWithHome(config.Prefix)
+	var apps []cf_command.Application
+	for i := 0; i < config.AppsPerSpace; i++ {
+		apps = append(apps, cf_command.Application{Name: fmt.Sprintf("%s-%s-%d-%d", config.Prefix, "app", spaceNumber, i)})
+	}
+
+	return &ConcurrentSpaceSetup{
+		Adapter: adapter,
+		ApiConnector: cf_command.ApiConnector{
+			Api:               config.Api,
+			AdminUser:         config.AdminUser,
+			AdminPassword:     config.AdminPassword,
+			SkipSSLValidation: config.SkipSSLValidation,
+			Adapter:           adapter,
+		},
+		OrgSpaceCreator: cf_command.OrgSpaceCreator{
+			Org:   orgName,
+			Space: fmt.Sprintf("%s-%s-%d", config.Prefix, "space", spaceNumber),
+			Quota: cf_command.Quota{
+				Name:             config.Prefix + "-quota",
+				Memory:           "1000G",
+				InstanceMemory:   -1,
+				Routes:           20000,
+				ServiceInstances: 100,
+				AppInstances:     -1,
+				RoutePorts:       -1,
+			},
+			Adapter: adapter,
+		},
+		AppPusher: cf_command.AppPusher{
+			Applications:            apps,
+			Adapter:                 adapter,
+			Concurrency:             config.Concurrency,
+			ManifestPath:            generateAppManifest(appsDir),
+			Directory:               filepath.Join(appsDir, "proxy"),
+			SkipIfPresent:           true,
+			DesiredRunningInstances: 1,
+		},
+	}
+}
+
+func generateAdapterWithHome(prefix string) *cf_cli_adapter.Adapter {
+	dir, err := os.MkdirTemp("", prefix)
+	if err != nil {
+		log.Fatalf("Failed to create a cf home dir")
+	}
+
+	return cf_cli_adapter.NewAdapterWithHome(dir)
+}
+
+func compileBinary() {
+	appsDir := os.Getenv("APPS_DIR")
+	if appsDir == "" {
+		log.Fatal("APPS_DIR not set")
+	}
+
+	buildCmd := exec.Command("go", "build", "-o", "proxy")
+	buildCmd.Dir = filepath.Join(appsDir, "proxy")
+	buildCmd.Env = append(os.Environ(),
+		"GOOS=linux",
+		"GOARCH=amd64",
+	)
+
+	output, err := buildCmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("compiling app binary:\nOutput: %s\nError: %s\n", output, err)
+	}
+}
+
+func generateAppManifest(appsDir string) string {
+	manifestGenerator := &manifest_generator.ManifestGenerator{}
+	appManifest := models.Manifest{
+		Applications: []models.Application{{
+			Name:      "proxy",
+			Memory:    "32M",
+			DiskQuota: "32M",
+			BuildPack: "binary_buildpack",
+			Instances: 1,
+			Command:   "./proxy",
+		}},
+	}
+	manifestPath, err := manifestGenerator.Generate(appManifest)
+	if err != nil {
+		log.Fatalf("generate manifest: %s", err)
+	}
+
+	return manifestPath
+}
+
+func createGlobalASGs(config Config) {
+	asgContent := testsupport.BuildASG(config.ASGSize)
+	asgFile, err := testsupport.CreateTempFile(asgContent)
+	if err != nil {
+		log.Fatalf("creating asg file: %s", err)
+	}
+
+	sem := make(chan bool, config.Concurrency)
+	for index := 0; index < config.GlobalAGGs; index++ {
+		sem <- true
+		go func(p string, i int) {
+			defer func() { <-sem }()
+			adapter := generateAdapterWithHome(p)
+			asgName := fmt.Sprintf("%s-global-%d-asg", p, i)
+
+			// check ASG and install if not OK
+			apiConnector := &cf_command.ApiConnector{
+				Api:               config.Api,
+				AdminUser:         config.AdminUser,
+				AdminPassword:     config.AdminPassword,
+				SkipSSLValidation: config.SkipSSLValidation,
+				Adapter:           adapter,
+			}
+			if err := apiConnector.Connect(); err != nil {
+				log.Fatalf("connecting to api: %s", err)
+			}
+			asgChecker := cf_command.ASGChecker{Adapter: adapter}
+			asgErr := asgChecker.CheckASG(asgName, asgContent)
+			if asgErr != nil {
+				// install ASG
+				asgInstaller := cf_command.ASGInstaller{Adapter: adapter}
+				if err = asgInstaller.InstallGlobalASG(asgName, asgFile); err != nil {
+					log.Fatalf("install asg: %s", err)
+				}
+			}
+		}(config.Prefix, index)
+	}
+
+	for i := 0; i < cap(sem); i++ {
+		sem <- true
+	}
+}
+
+func bindManyASGsToThisSpace(asgNames []string, orgName, spaceName string, adapter *cf_cli_adapter.Adapter) {
+	for _, asg := range asgNames {
+		if err := adapter.BindSecurityGroup(asg, orgName, spaceName); err != nil {
+			log.Fatalf("binding asg %s to org %s, space %s: %s", asg, orgName, spaceName, err)
+		}
+	}
+}
+
+func createManyASGs(howMany, asgSize int, prefix string, adapter *cf_cli_adapter.Adapter) []string {
+	var asgNames []string
+	for i := 0; i < howMany; i++ {
+		asgName := fmt.Sprintf("%s-many-%d-asg", prefix, i)
+		asgNames = append(asgNames, asgName)
+		asgContent := testsupport.BuildASG(asgSize)
+		asgFile, err := testsupport.CreateTempFile(asgContent)
+		if err != nil {
+			log.Fatalf("creating asg file: %s", err)
+		}
+
+		// check ASG and create if not OK
+		asgChecker := cf_command.ASGChecker{Adapter: adapter}
+		asgErr := asgChecker.CheckASG(asgName, asgContent)
+		if asgErr != nil {
+			// install ASG
+			if err := adapter.DeleteSecurityGroup(asgName); err != nil {
+				log.Fatalf("deleting security group: %s", err)
+			}
+			if err := adapter.CreateSecurityGroup(asgName, asgFile); err != nil {
+				log.Fatalf("creating security group: %s", err)
+			}
+		}
+	}
+
+	return asgNames
+}
+
+func createAndBindOneASGToThisSpace(asgName string, asgSize int, osc cf_command.OrgSpaceCreator, adapter *cf_cli_adapter.Adapter) {
+	asgContent := testsupport.BuildASG(asgSize)
+	asgFile, err := testsupport.CreateTempFile(asgContent)
+	if err != nil {
+		log.Fatalf("creating asg file: %s", err)
+	}
+
+	// check ASG and install if not OK
+	asgChecker := cf_command.ASGChecker{Adapter: adapter}
+	asgErr := asgChecker.CheckASG(asgName, asgContent)
+	if asgErr != nil {
+		// install ASG
+		asgInstaller := cf_command.ASGInstaller{Adapter: adapter}
+		if err = asgInstaller.InstallASG(asgName, asgFile, osc.Org, osc.Space); err != nil {
+			log.Fatalf("install asg: %s", err)
+		}
+	}
+}
+
+func parseConfig() Config {
+	configPath := flag.String("config", "", "path to the config file")
+	flag.Parse()
+
+	if *configPath == "" {
+		log.Fatal("must include config file with --config")
+	}
+
+	configBytes, err := ioutil.ReadFile(*configPath)
+	if err != nil {
+		log.Fatalf("error reading config: %s", err)
+	}
+
+	var config Config
+	if err := json.Unmarshal(configBytes, &config); err != nil {
+		log.Fatalf("error unmarshaling config: %s", err)
+	}
+
+	if config.Prefix == "" {
+		config.Prefix = "scale-asg"
+	}
+	config.Prefix = strings.TrimSuffix(config.Prefix, "-")
+
+	if config.SpacesWithOneASG > config.TotalSpaces {
+		log.Fatalf("total_spaces must be greater than or equal to spaces_with_one_asg")
+	}
+
+	if config.Concurrency < 1 {
+		config.Concurrency = 1
+	}
+
+	return config
+}

--- a/src/code.cloudfoundry.org/cf-pusher/models/tick.go
+++ b/src/code.cloudfoundry.org/cf-pusher/models/tick.go
@@ -6,6 +6,7 @@ type Manifest struct {
 
 type Application struct {
 	Name      string      `yaml:"name,omitempty"`
+	Command   string      `yaml:"command,omitempty"`
 	Memory    string      `yaml:"memory,omitempty"`
 	DiskQuota string      `yaml:"disk_quota,omitempty"`
 	BuildPack string      `yaml:"buildpack,omitempty"`

--- a/src/code.cloudfoundry.org/test/performance-asg/prometheus/README.md
+++ b/src/code.cloudfoundry.org/test/performance-asg/prometheus/README.md
@@ -1,0 +1,10 @@
+To use:
+
+1. Clone the [prometheus-boshrelease](https://github.com/bosh-prometheus/prometheus-boshrelease) to ~/workspace
+1. Deploy your CF with the opsfile [add-prometheus-uaa-clients.yml](https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/manifests/operators/cf/add-prometheus-uaa-clients.yml)
+1. Look up the values in credhub for the created clients:
+    1. `credhub find -n uaa_clients_cf_exporter_secret`
+    1. `credhub get -n <path from above>`
+    1.  repeat for `uaa_clients_firehose_exporter_secret`
+1. Fill empty values in `./change-me-deployment-vars.yml` (Note that bosh client/secret doesn't work for username/password)
+1. Run `./deploy.sh` to deploy prometheus and grafana that scrapes from your cf/bosh

--- a/src/code.cloudfoundry.org/test/performance-asg/prometheus/change-me-deployment-vars.yml
+++ b/src/code.cloudfoundry.org/test/performance-asg/prometheus/change-me-deployment-vars.yml
@@ -1,0 +1,14 @@
+system_domain: 
+cf_deployment_name: 
+skip_ssl_verify: false
+uaa_clients_cf_exporter_secret: 
+uaa_clients_firehose_exporter_secret: 
+metron_deployment_name: 
+traffic_controller_external_port: 443
+metrics_environment: 
+bosh_username: 
+bosh_password: 
+default_stemcell_os: 
+default_vm_type: 
+default_network: 
+default_az: 

--- a/src/code.cloudfoundry.org/test/performance-asg/prometheus/change-prometheus-defaults.yml
+++ b/src/code.cloudfoundry.org/test/performance-asg/prometheus/change-prometheus-defaults.yml
@@ -1,0 +1,133 @@
+---
+# stemcell
+- type: replace
+  path: /stemcells/alias=default?/os
+  value: ((default_stemcell_os))
+
+# alertmanager
+- type: replace
+  path: /instance_groups/name=alertmanager/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=alertmanager/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=alertmanager/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=alertmanager/vm_extensions?/-
+  value: public_ip
+
+# prometheus2
+- type: replace
+  path: /instance_groups/name=prometheus2/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=prometheus2/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=prometheus2/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=prometheus2/vm_extensions?/-
+  value: public_ip
+
+# nginx
+- type: replace
+  path: /instance_groups/name=nginx/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=nginx/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=nginx/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=nginx/vm_extensions?/-
+  value: public_ip
+
+# database
+- type: replace
+  path: /instance_groups/name=database/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=database/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=database/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=database/vm_extensions?/-
+  value: public_ip
+
+# grafana
+- type: replace
+  path: /instance_groups/name=grafana/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=grafana/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=grafana/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=grafana/vm_extensions?/-
+  value: public_ip
+
+# firehose?
+- type: replace
+  path: /instance_groups/name=firehose?/vm_type
+  value: ((default_vm_type))
+
+- type: replace
+  path: /instance_groups/name=firehose?/networks/name=default?
+  value: 
+    name: ((default_network))
+
+- type: replace
+  path: /instance_groups/name=firehose?/azs/0
+  value: ((default_az))
+
+- type: replace
+  path: /instance_groups/name=firehose?/vm_extensions?/-
+  value: public_ip
+
+
+# remove the cf_exporter (we don't care about those metrics and it drives too much capi load
+- type: remove
+  path: /instance_groups/name=prometheus2/jobs/name=cf_exporter?
+
+# latest routing release
+- type: replace
+  path: /releases/name=routing?
+  value:
+    name: routing
+    version: latest
+
+# latest bpm release
+- type: replace
+  path: /releases/name=bpm?
+  value:
+    name: bpm
+    version: latest
+

--- a/src/code.cloudfoundry.org/test/performance-asg/prometheus/dashboard.json
+++ b/src/code.cloudfoundry.org/test/performance-asg/prometheus/dashboard.json
@@ -1,0 +1,840 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": 59,
+  "iteration": 1646933446671,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [
+        "v2"
+      ],
+      "targetBlank": true,
+      "title": "CF",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "panels": [],
+      "title": "ASG Syncing Metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 9,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_vxlan_policy_agent_asg_total_poll_time)/1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "asg retrieval",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_vxlan_policy_agent_asg_iptables_enforce_time)/1000",
+          "interval": "",
+          "legendFormat": "iptables enforce",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_vxlan_policy_agent_asg_iptables_cleanup_time)/1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "iptables cleanup",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Vxlan Policy Agent Timings (seconds)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1166",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1167",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_policy_server_asg_syncer_security_groups_retrieval_from_cc_time)/1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "retrieval from cc",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_policy_server_asg_syncer_security_groups_store_replace_success_time)/1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "store",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_policy_server_asg_syncer_security_groups_total_sync_time)/1000",
+          "interval": "",
+          "legendFormat": "total sync",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ASG Syncer Timings (seconds)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1166",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1167",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.15",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(firehose_value_metric_netmon_ip_tables_rule_count)by(bosh_job_ip)\n",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "{{bosh_job_ip}}",
+          "refId": "C"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "iptables rules per cell",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 2,
+      "panels": [],
+      "title": "CPU/Memory",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(bosh_job_process_cpu_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_process_name=~\"(policy-server-asg-syncer|policy-server-internal|vxlan-policy-agent)\"}) by(bosh_job_process_name)",
+          "interval": "",
+          "legendFormat": "{{bosh_job_process_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Networking CPU %",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:457",
+          "decimals": null,
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:458",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(bosh_job_process_mem_kb{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_process_name=~\"(policy-server-asg-syncer|policy-server-internal|vxlan-policy-agent)\"}/1024) by(bosh_job_process_name)",
+          "interval": "",
+          "legendFormat": "{{bosh_job_process_name}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Networking Memory (mb)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:2130",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:2131",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(bosh_job_process_cpu_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_process_name=~\"cloud_controller_ng\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "cc cpu({{bosh_job_ip}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CC CPU %",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:457",
+          "decimals": null,
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:458",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.15",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg(bosh_job_process_mem_kb{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_process_name=~\"cloud_controller_ng\"}/1024) by(bosh_job_ip)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "cc memory({{bosh_job_ip}})",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CC Memory (mb)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1111",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "4000",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1112",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "redcola",
+          "value": "redcola"
+        },
+        "datasource": null,
+        "definition": "label_values(firehose_value_metric_cc_job_queue_length_total, environment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "environment",
+        "options": [],
+        "query": {
+          "query": "label_values(firehose_value_metric_cc_job_queue_length_total, environment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "cf-6aa0c3030a3f0c1ff0c0",
+          "value": "cf-6aa0c3030a3f0c1ff0c0"
+        },
+        "datasource": null,
+        "definition": "label_values(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\"}, bosh_deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "bosh_deployment",
+        "options": [
+          {
+            "selected": true,
+            "text": "cf-6aa0c3030a3f0c1ff0c0",
+            "value": "cf-6aa0c3030a3f0c1ff0c0"
+          }
+        ],
+        "query": {
+          "query": "label_values(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\"}, bosh_deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ASG Scale Test",
+  "uid": "LcJkcvLnk",
+  "version": 10
+}

--- a/src/code.cloudfoundry.org/test/performance-asg/prometheus/deploy.sh
+++ b/src/code.cloudfoundry.org/test/performance-asg/prometheus/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+
+BOSH_ENVIRONMENT=${BOSH_ENVIRONMENT:?must set BOSH_ENVIRONMENT env var}
+BOSH_CA_CERT=${BOSH_CA_CERT:?must set BOSH_CA_CERT env var}
+
+PROMETHEUS_BOSH_RELEASE_DIR=${PROMETHEUS_BOSH_RELEASE_DIR:=~/workspace/prometheus-boshrelease}
+ASG_TEST_DIR=${ASG_TEST_DIR:=~/workspace/cf-networking-release/src/code.cloudfoundry.org/test/performance-asg/prometheus}
+
+bosh -d prometheus deploy "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/prometheus.yml" \
+  --vars-store "${ASG_TEST_DIR}/change-me-deployment-vars.yml" \
+  -o "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/operators/monitor-bosh.yml" \
+  -v bosh_url="${BOSH_ENVIRONMENT}" \
+  --var-file bosh_ca_cert="${BOSH_CA_CERT}" \
+  -o "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/operators/monitor-cf.yml" \
+  -o "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/operators/enable-cf-route-registrar.yml" \
+  -o "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/operators/enable-cf-api-v3.yml" \
+  -o "${PROMETHEUS_BOSH_RELEASE_DIR}/manifests/operators/enable-cf-loggregator-v2.yml" \
+  -o "${ASG_TEST_DIR}/change-prometheus-defaults.yml" \
+  "$@"

--- a/src/code.cloudfoundry.org/test/performance-asg/run.sh
+++ b/src/code.cloudfoundry.org/test/performance-asg/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e -u
+
+THIS_DIR=$(cd $(dirname $0) && pwd)
+cd $THIS_DIR
+
+export CONFIG=/tmp/test-config.json
+export APPS_DIR=../../../example-apps
+
+echo "
+{
+  \"api\": \"api.sys.pacificblue.cf-app.com\",
+  \"admin_user\": \"admin\",
+  \"admin_password\": \"${ADMIN_PASSWORD}\",
+  \"skip_ssl_validation\": true,
+  \"use_http\": true,
+  \"concurrency\": 10,
+  \"prefix\":\"scale-asg\",
+  \"asg_size\": 100,
+  \"global_asgs\": 5,
+  \"total_spaces\": 2,
+  \"spaces_with_one_asg\": 1,
+  \"how_many_asgs_is_many\": 2,
+  \"apps_per_space\": 1
+}
+" > $CONFIG
+
+go run ../../cf-pusher/cmd/multispace-pusher/main.go --config "${CONFIG}"
+
+
+# Cleanup scripts
+# cf delete-org scale-asg-org -f
+# cf security-groups | grep 'scale-asg-' | cut -d' ' -f1 | xargs -n1 -P16 cf delete-security-group -f


### PR DESCRIPTION
There are 2 main parts here:
1. Script to create many ASGs/apps
    This script `src/code.cloudfoundry.org/test/performance-asg/run.sh` will idempotently create a configurable number of Global ASGs, space-specific ASGs, and apps.
2. Prometheus/Grafana setup and dashboard
    The README in
    `src/code.cloudfoundry.org/test/performance-asg/prometheus` walks
    you through how to deploy the `prometheus-bosh-release` and
    configure a helpful dashboard to monitor networking components and
    cloud controller.

Signed-off-by: David Sabeti <sabetid@vmware.com>
Signed-off-by: Amelia Downs <adowns@vmware.com>
Signed-off-by: Maria Shaldybin <mariash@vmware.com>