### PR TITLE
Use CAPI's /internal/v4/asg_last_updated endpoint

### DIFF
--- a/jobs/policy-server-asg-syncer/spec
+++ b/jobs/policy-server-asg-syncer/spec
@@ -6,6 +6,9 @@ templates:
   database_ca.crt.erb: config/certs/database_ca.crt
   uaa_ca.crt.erb: config/certs/uaa_ca.crt
   cc_ca.crt.erb: config/certs/cc_ca.crt
+  cc_internal_ca.crt.erb: config/certs/cc_internal_ca.crt
+  cc_internal_client.crt.erb: config/certs/cc_internal_client.crt
+  cc_internal_client.key.erb: config/certs/cc_internal_client.key
   locket_ca.crt.erb: config/certs/locket_ca.crt
   locket.crt.erb: config/certs/locket.crt
   locket.key.erb: config/certs/locket.key
@@ -22,6 +25,8 @@ consumes:
 - name: cloud_controller_https_endpoint
   type: cloud_controller_https_endpoint
   optional: true
+- name: cloud_controller_mtls_endpoint
+  type: cloud_controller_mtls_endpoint
 
 properties:
   disable:
@@ -53,6 +58,12 @@ properties:
       The value supplied to this property must match the value supplied to the Cloud Controller
       property `cc.external_port`.
     example: 9022
+
+  cc_internal.client_cert:
+    description: "Client certificate for cloud controller"
+
+  cc_internal.client_key:
+    description: "Client private key for cloud controller"
 
   database.connect_timeout_seconds:
     description: "Connection timeout between the policy server and its database."

--- a/jobs/policy-server-asg-syncer/templates/cc_internal_ca.crt.erb
+++ b/jobs/policy-server-asg-syncer/templates/cc_internal_ca.crt.erb
@@ -1,0 +1,1 @@
+<%= link("cloud_controller_mtls_endpoint").p("cc.mutual_tls.ca_cert") %>

--- a/jobs/policy-server-asg-syncer/templates/cc_internal_client.crt.erb
+++ b/jobs/policy-server-asg-syncer/templates/cc_internal_client.crt.erb
@@ -1,0 +1,1 @@
+<%= p("cc_internal.client_cert") %>

--- a/jobs/policy-server-asg-syncer/templates/cc_internal_client.key.erb
+++ b/jobs/policy-server-asg-syncer/templates/cc_internal_client.key.erb
@@ -1,0 +1,1 @@
+<%= p("cc_internal.client_key") %>

--- a/jobs/policy-server-asg-syncer/templates/policy-server-asg-syncer.json.erb
+++ b/jobs/policy-server-asg-syncer/templates/policy-server-asg-syncer.json.erb
@@ -23,6 +23,10 @@
 
       raise '`cc_hostname` and `cc_port` properties were not supplied as manifest properties, nor were found in `cloud_controller_https_endpoint` link'
     end
+    
+    def get_cc_internal_url
+     return "https://#{link('cloud_controller_mtls_endpoint').p('cc.internal_service_hostname')}:#{link('cloud_controller_mtls_endpoint').p('cc.tls_port')}"
+    end
 
     def asg_poll_interval_seconds
       interval = p('asg_poll_interval_seconds')
@@ -75,6 +79,10 @@
       'uaa_ca' => '/var/vcap/jobs/policy-server-asg-syncer/config/certs/uaa_ca.crt',
       'cc_url' => get_cc_url,
       'cc_ca_cert' => '/var/vcap/jobs/policy-server-asg-syncer/config/certs/cc_ca.crt',
+      'cc_internal_url' => get_cc_internal_url,
+      'cc_internal_ca_cert' => '/var/vcap/jobs/policy-server-asg-syncer/config/certs/cc_internal_ca.crt',
+      'cc_internal_client_cert' => '/var/vcap/jobs/policy-server-asg-syncer/config/certs/cc_internal_client.crt',
+      'cc_internal_client_key' => '/var/vcap/jobs/policy-server-asg-syncer/config/certs/cc_internal_client.key',
       'log_prefix' => 'cfnetworking',
       'log_level' => p('log_level'),
       "metron_address" => "127.0.0.1:#{p("metron_port")}",

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
@@ -3,6 +3,7 @@ package fakes
 
 import (
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/policy-server/cc_client"
 )
@@ -61,6 +62,19 @@ type CCClient struct {
 	}
 	getSecurityGroupsReturnsOnCall map[int]struct {
 		result1 []cc_client.SecurityGroupResource
+		result2 error
+	}
+	GetSecurityGroupsLastUpdateStub        func(string) (time.Time, error)
+	getSecurityGroupsLastUpdateMutex       sync.RWMutex
+	getSecurityGroupsLastUpdateArgsForCall []struct {
+		arg1 string
+	}
+	getSecurityGroupsLastUpdateReturns struct {
+		result1 time.Time
+		result2 error
+	}
+	getSecurityGroupsLastUpdateReturnsOnCall map[int]struct {
+		result1 time.Time
 		result2 error
 	}
 	GetSpaceStub        func(string, string) (*cc_client.SpaceResponse, error)
@@ -398,6 +412,70 @@ func (fake *CCClient) GetSecurityGroupsReturnsOnCall(i int, result1 []cc_client.
 	}{result1, result2}
 }
 
+func (fake *CCClient) GetSecurityGroupsLastUpdate(arg1 string) (time.Time, error) {
+	fake.getSecurityGroupsLastUpdateMutex.Lock()
+	ret, specificReturn := fake.getSecurityGroupsLastUpdateReturnsOnCall[len(fake.getSecurityGroupsLastUpdateArgsForCall)]
+	fake.getSecurityGroupsLastUpdateArgsForCall = append(fake.getSecurityGroupsLastUpdateArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GetSecurityGroupsLastUpdateStub
+	fakeReturns := fake.getSecurityGroupsLastUpdateReturns
+	fake.recordInvocation("GetSecurityGroupsLastUpdate", []interface{}{arg1})
+	fake.getSecurityGroupsLastUpdateMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CCClient) GetSecurityGroupsLastUpdateCallCount() int {
+	fake.getSecurityGroupsLastUpdateMutex.RLock()
+	defer fake.getSecurityGroupsLastUpdateMutex.RUnlock()
+	return len(fake.getSecurityGroupsLastUpdateArgsForCall)
+}
+
+func (fake *CCClient) GetSecurityGroupsLastUpdateCalls(stub func(string) (time.Time, error)) {
+	fake.getSecurityGroupsLastUpdateMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdateMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdateStub = stub
+}
+
+func (fake *CCClient) GetSecurityGroupsLastUpdateArgsForCall(i int) string {
+	fake.getSecurityGroupsLastUpdateMutex.RLock()
+	defer fake.getSecurityGroupsLastUpdateMutex.RUnlock()
+	argsForCall := fake.getSecurityGroupsLastUpdateArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *CCClient) GetSecurityGroupsLastUpdateReturns(result1 time.Time, result2 error) {
+	fake.getSecurityGroupsLastUpdateMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdateMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdateStub = nil
+	fake.getSecurityGroupsLastUpdateReturns = struct {
+		result1 time.Time
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CCClient) GetSecurityGroupsLastUpdateReturnsOnCall(i int, result1 time.Time, result2 error) {
+	fake.getSecurityGroupsLastUpdateMutex.Lock()
+	defer fake.getSecurityGroupsLastUpdateMutex.Unlock()
+	fake.GetSecurityGroupsLastUpdateStub = nil
+	if fake.getSecurityGroupsLastUpdateReturnsOnCall == nil {
+		fake.getSecurityGroupsLastUpdateReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+			result2 error
+		})
+	}
+	fake.getSecurityGroupsLastUpdateReturnsOnCall[i] = struct {
+		result1 time.Time
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CCClient) GetSpace(arg1 string, arg2 string) (*cc_client.SpaceResponse, error) {
 	fake.getSpaceMutex.Lock()
 	ret, specificReturn := fake.getSpaceReturnsOnCall[len(fake.getSpaceArgsForCall)]
@@ -675,6 +753,8 @@ func (fake *CCClient) Invocations() map[string][][]interface{} {
 	defer fake.getLiveSpaceGUIDsMutex.RUnlock()
 	fake.getSecurityGroupsMutex.RLock()
 	defer fake.getSecurityGroupsMutex.RUnlock()
+	fake.getSecurityGroupsLastUpdateMutex.RLock()
+	defer fake.getSecurityGroupsLastUpdateMutex.RUnlock()
 	fake.getSpaceMutex.RLock()
 	defer fake.getSpaceMutex.RUnlock()
 	fake.getSpaceGUIDsMutex.RLock()

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
@@ -77,6 +77,20 @@ type CCClient struct {
 		result1 time.Time
 		result2 error
 	}
+	GetSecurityGroupsWithPageStub        func(string, int) (cc_client.GetSecurityGroupsResponse, error)
+	getSecurityGroupsWithPageMutex       sync.RWMutex
+	getSecurityGroupsWithPageArgsForCall []struct {
+		arg1 string
+		arg2 int
+	}
+	getSecurityGroupsWithPageReturns struct {
+		result1 cc_client.GetSecurityGroupsResponse
+		result2 error
+	}
+	getSecurityGroupsWithPageReturnsOnCall map[int]struct {
+		result1 cc_client.GetSecurityGroupsResponse
+		result2 error
+	}
 	GetSpaceStub        func(string, string) (*cc_client.SpaceResponse, error)
 	getSpaceMutex       sync.RWMutex
 	getSpaceArgsForCall []struct {
@@ -476,6 +490,71 @@ func (fake *CCClient) GetSecurityGroupsLastUpdateReturnsOnCall(i int, result1 ti
 	}{result1, result2}
 }
 
+func (fake *CCClient) GetSecurityGroupsWithPage(arg1 string, arg2 int) (cc_client.GetSecurityGroupsResponse, error) {
+	fake.getSecurityGroupsWithPageMutex.Lock()
+	ret, specificReturn := fake.getSecurityGroupsWithPageReturnsOnCall[len(fake.getSecurityGroupsWithPageArgsForCall)]
+	fake.getSecurityGroupsWithPageArgsForCall = append(fake.getSecurityGroupsWithPageArgsForCall, struct {
+		arg1 string
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.GetSecurityGroupsWithPageStub
+	fakeReturns := fake.getSecurityGroupsWithPageReturns
+	fake.recordInvocation("GetSecurityGroupsWithPage", []interface{}{arg1, arg2})
+	fake.getSecurityGroupsWithPageMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CCClient) GetSecurityGroupsWithPageCallCount() int {
+	fake.getSecurityGroupsWithPageMutex.RLock()
+	defer fake.getSecurityGroupsWithPageMutex.RUnlock()
+	return len(fake.getSecurityGroupsWithPageArgsForCall)
+}
+
+func (fake *CCClient) GetSecurityGroupsWithPageCalls(stub func(string, int) (cc_client.GetSecurityGroupsResponse, error)) {
+	fake.getSecurityGroupsWithPageMutex.Lock()
+	defer fake.getSecurityGroupsWithPageMutex.Unlock()
+	fake.GetSecurityGroupsWithPageStub = stub
+}
+
+func (fake *CCClient) GetSecurityGroupsWithPageArgsForCall(i int) (string, int) {
+	fake.getSecurityGroupsWithPageMutex.RLock()
+	defer fake.getSecurityGroupsWithPageMutex.RUnlock()
+	argsForCall := fake.getSecurityGroupsWithPageArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CCClient) GetSecurityGroupsWithPageReturns(result1 cc_client.GetSecurityGroupsResponse, result2 error) {
+	fake.getSecurityGroupsWithPageMutex.Lock()
+	defer fake.getSecurityGroupsWithPageMutex.Unlock()
+	fake.GetSecurityGroupsWithPageStub = nil
+	fake.getSecurityGroupsWithPageReturns = struct {
+		result1 cc_client.GetSecurityGroupsResponse
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CCClient) GetSecurityGroupsWithPageReturnsOnCall(i int, result1 cc_client.GetSecurityGroupsResponse, result2 error) {
+	fake.getSecurityGroupsWithPageMutex.Lock()
+	defer fake.getSecurityGroupsWithPageMutex.Unlock()
+	fake.GetSecurityGroupsWithPageStub = nil
+	if fake.getSecurityGroupsWithPageReturnsOnCall == nil {
+		fake.getSecurityGroupsWithPageReturnsOnCall = make(map[int]struct {
+			result1 cc_client.GetSecurityGroupsResponse
+			result2 error
+		})
+	}
+	fake.getSecurityGroupsWithPageReturnsOnCall[i] = struct {
+		result1 cc_client.GetSecurityGroupsResponse
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CCClient) GetSpace(arg1 string, arg2 string) (*cc_client.SpaceResponse, error) {
 	fake.getSpaceMutex.Lock()
 	ret, specificReturn := fake.getSpaceReturnsOnCall[len(fake.getSpaceArgsForCall)]
@@ -755,6 +834,8 @@ func (fake *CCClient) Invocations() map[string][][]interface{} {
 	defer fake.getSecurityGroupsMutex.RUnlock()
 	fake.getSecurityGroupsLastUpdateMutex.RLock()
 	defer fake.getSecurityGroupsLastUpdateMutex.RUnlock()
+	fake.getSecurityGroupsWithPageMutex.RLock()
+	defer fake.getSecurityGroupsWithPageMutex.RUnlock()
 	fake.getSpaceMutex.RLock()
 	defer fake.getSpaceMutex.RUnlock()
 	fake.getSpaceGUIDsMutex.RLock()

--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server-asg-syncer/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server-asg-syncer/main.go
@@ -151,7 +151,7 @@ func main() {
 		{Name: "asg-syncer", Runner: asgSyncer},
 	}
 
-	logger.Info("starting asg syncer", lager.Data{"interval": conf.ASGSyncInterval})
+	logger.Info("starting-asg-syncer", lager.Data{"interval": conf.ASGSyncInterval})
 
 	group := grouper.NewOrdered(os.Interrupt, members)
 	monitor := ifrit.Invoke(sigmon.New(group))

--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
@@ -147,8 +147,8 @@ func main() {
 	}
 
 	ccClient := &cc_client.Client{
-		JSONClient: json_client.New(logger.Session("cc-json-client"), httpClient, conf.CCURL),
-		Logger:     logger,
+		ExternalJSONClient: json_client.New(logger.Session("cc-json-client"), httpClient, conf.CCURL),
+		Logger:             logger,
 	}
 
 	policyGuard := handlers.NewPolicyGuard(uaaClient, ccClient)

--- a/src/code.cloudfoundry.org/policy-server/config/asg_syncer_config.go
+++ b/src/code.cloudfoundry.org/policy-server/config/asg_syncer_config.go
@@ -12,21 +12,25 @@ import (
 )
 
 type ASGSyncerConfig struct {
-	ASGSyncInterval   int       `json:"asg_poll_interval_seconds" validate:"min=0"`
-	RetryDeadline     int       `json:"retry_deadline_seconds" validate:"min=1"`
-	UUID              string    `json:"uuid" validate:"nonzero"`
-	Database          db.Config `json:"database" validate:"nonzero"`
-	UAAClient         string    `json:"uaa_client" validate:"nonzero"`
-	UAAClientSecret   string    `json:"uaa_client_secret" validate:"nonzero"`
-	UAACA             string    `json:"uaa_ca"`
-	UAAURL            string    `json:"uaa_url" validate:"nonzero"`
-	UAAPort           int       `json:"uaa_port" validate:"nonzero"`
-	CCURL             string    `json:"cc_url" validate:"nonzero"`
-	CCCA              string    `json:"cc_ca_cert"`
-	LogLevel          string    `json:"log_level"`
-	LogPrefix         string    `json:"log_prefix" validate:"nonzero"`
-	MetronAddress     string    `json:"metron_address" validate:"nonzero"`
-	SkipSSLValidation bool      `json:"skip_ssl_validation"`
+	ASGSyncInterval      int       `json:"asg_poll_interval_seconds" validate:"min=0"`
+	RetryDeadline        int       `json:"retry_deadline_seconds" validate:"min=1"`
+	UUID                 string    `json:"uuid" validate:"nonzero"`
+	Database             db.Config `json:"database" validate:"nonzero"`
+	UAAClient            string    `json:"uaa_client" validate:"nonzero"`
+	UAAClientSecret      string    `json:"uaa_client_secret" validate:"nonzero"`
+	UAACA                string    `json:"uaa_ca"`
+	UAAURL               string    `json:"uaa_url" validate:"nonzero"`
+	UAAPort              int       `json:"uaa_port" validate:"nonzero"`
+	CCURL                string    `json:"cc_url" validate:"nonzero"`
+	CCInternalURL        string    `json:"cc_internal_url" validate:"nonzero"`
+	CCCA                 string    `json:"cc_ca_cert"`
+	CCInternalCA         string    `json:"cc_internal_ca_cert"`
+	CCInternalClientCert string    `json:"cc_internal_client_cert"`
+	CCInternalClientKey  string    `json:"cc_internal_client_key"`
+	LogLevel             string    `json:"log_level"`
+	LogPrefix            string    `json:"log_prefix" validate:"nonzero"`
+	MetronAddress        string    `json:"metron_address" validate:"nonzero"`
+	SkipSSLValidation    bool      `json:"skip_ssl_validation"`
 	locket.ClientLocketConfig
 }
 

--- a/src/code.cloudfoundry.org/policy-server/config/asg_syncer_config_test.go
+++ b/src/code.cloudfoundry.org/policy-server/config/asg_syncer_config_test.go
@@ -34,17 +34,21 @@ var _ = Describe("ASGSyncerConfig", func() {
 					"timeout":       5,
 					"database_name": "network_policy",
 				},
-				"uaa_client":          "some-uaa-client",
-				"uaa_client_secret":   "some-uaa-client-secret",
-				"uaa_ca":              "some/ca/cert/uaa.ca",
-				"uaa_url":             "uaa.service.cf.internal",
-				"uaa_port":            8443,
-				"cc_url":              "cc.service.cf.internal",
-				"cc_ca_cert":          "some/ca/cert/cc.ca",
-				"log_prefix":          "cfnetworking",
-				"log_level":           "debug",
-				"metron_address":      "127.0.0.1:3457",
-				"skip_ssl_validation": true,
+				"uaa_client":              "some-uaa-client",
+				"uaa_client_secret":       "some-uaa-client-secret",
+				"uaa_ca":                  "some/ca/cert/uaa.ca",
+				"uaa_url":                 "uaa.service.cf.internal",
+				"uaa_port":                8443,
+				"cc_url":                  "cc.service.cf.internal:9024",
+				"cc_internal_url":         "cc.service.cf.internal:9023",
+				"cc_ca_cert":              "some/ca/cert/cc.ca",
+				"cc_internal_ca_cert":     "cert/cc_internal_ca.crt",
+				"cc_internal_client_cert": "cert/cc_internal_client.crt",
+				"cc_internal_client_key":  "cert/cc_internal_client.key",
+				"log_prefix":              "cfnetworking",
+				"log_level":               "debug",
+				"metron_address":          "127.0.0.1:3457",
+				"skip_ssl_validation":     true,
 				"locket": map[string]interface{}{
 					"locket_address":          "http://6.5.4.3",
 					"locket_ca_cert_file":     "some/ca/cert/locket.ca",
@@ -76,8 +80,12 @@ var _ = Describe("ASGSyncerConfig", func() {
 				Expect(c.UAACA).To(Equal("some/ca/cert/uaa.ca"))
 				Expect(c.UAAURL).To(Equal("uaa.service.cf.internal"))
 				Expect(c.UAAPort).To(Equal(8443))
-				Expect(c.CCURL).To(Equal("cc.service.cf.internal"))
+				Expect(c.CCURL).To(Equal("cc.service.cf.internal:9024"))
+				Expect(c.CCInternalURL).To(Equal("cc.service.cf.internal:9023"))
 				Expect(c.CCCA).To(Equal("some/ca/cert/cc.ca"))
+				Expect(c.CCInternalCA).To(Equal("cert/cc_internal_ca.crt"))
+				Expect(c.CCInternalClientCert).To(Equal("cert/cc_internal_client.crt"))
+				Expect(c.CCInternalClientKey).To(Equal("cert/cc_internal_client.key"))
 				Expect(c.LogPrefix).To(Equal("cfnetworking"))
 				Expect(c.LogLevel).To(Equal("debug"))
 				Expect(c.MetronAddress).To(Equal("127.0.0.1:3457"))
@@ -129,6 +137,7 @@ var _ = Describe("ASGSyncerConfig", func() {
 			Entry("missing uaa url", "uaa_url", "UAAURL: zero value"),
 			Entry("missing uaa port", "uaa_port", "UAAPort: zero value"),
 			Entry("missing cc url", "cc_url", "CCURL: zero value"),
+			Entry("missing cc internal url", "cc_internal_url", "CCInternalURL: zero value"),
 		)
 
 		Describe("asg sync interval", func() {

--- a/src/code.cloudfoundry.org/policy-server/integration/helpers/helpers.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/helpers/helpers.go
@@ -219,6 +219,7 @@ func DefaultTestConfigWithCCServer(dbConfig db.Config, metronAddress string, fix
 		UAAURL:            "http://" + UAAHost,
 		UAAPort:           UAAPort,
 		CCURL:             mockCCServerURL,
+		CCInternalURL:     mockCCServerURL,
 		CCCA:              "/some/ca/cert",
 		LogPrefix:         "testprefix",
 		MetronAddress:     metronAddress,


### PR DESCRIPTION
Two main goals were accomplished by using this endpoint:
1. ASG syncing can be skipped by checking this endpoint and seeing that no updates to the ASGs have occurred
2. ASG Pagination has been simplified by checking this endpoint for updates between requests for different pages of ASGs