### PR TITLE
policy-server-asg-syncer - checking initial time fix

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer.go
+++ b/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer.go
@@ -64,8 +64,12 @@ func (a *ASGSyncer) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	}
 }
 
+func timeIsInitial(timetamp time.Time) bool {
+	return timetamp.IsZero() || timetamp.UnixNano() == 0
+}
+
 func valueHasNotBeenUpdated(ccTimetamp, localTimestamp time.Time) bool {
-	return !ccTimetamp.IsZero() && !ccTimetamp.After(localTimestamp)
+	return !timeIsInitial(ccTimetamp) && !ccTimetamp.After(localTimestamp)
 }
 
 func (a *ASGSyncer) Poll() error {
@@ -73,7 +77,7 @@ func (a *ASGSyncer) Poll() error {
 	a.Logger.Debug("asg-sync-started")
 	defer a.Logger.Debug("asg-sync-complete")
 
-	if a.lastSyncTime.IsZero() {
+	if timeIsInitial(a.lastSyncTime) {
 		a.Logger.Debug("initializing-lastSyncTime")
 		a.lastSyncTime = a.Clock.Now()
 	}


### PR DESCRIPTION
Initial time can has value: `1970-01-01T00:00:00Z`
Issue: https://github.com/cloudfoundry/cf-networking-release/issues/168