### PR TITLE
Cleanup stale policies in acceptance tests

### DIFF
--- a/src/code.cloudfoundry.org/cf-pusher/cf_cli_adapter/adapter.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_cli_adapter/adapter.go
@@ -201,6 +201,10 @@ func (a *Adapter) RemoveNetworkPolicy(sourceApp, destApp string, port int, proto
 	return a.runCommandWithTimeout(cmd)
 }
 
+func (a *Adapter) CleanupStaleNetworkPolicies() ([]byte, error) {
+	return a.Curl("POST", "/networking/v0/external/policies/cleanup", "")
+}
+
 func (a *Adapter) CreateQuota(name, memory string, instanceMemory, routes, serviceInstances, appInstances, routePorts int) error {
 	instanceMemoryStr := fmt.Sprintf("%d", instanceMemory)
 	routesStr := fmt.Sprintf("%d", routes)

--- a/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
@@ -19,6 +19,8 @@ var _ = Describe("ASGs and Overlay Policy interaction", func() {
 	AfterEach(func() {
 		By("deleting the org")
 		Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
+		_, err := cfCLI.CleanupStaleNetworkPolicies()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Context("when a wide open ASG is configured", func() {
@@ -129,6 +131,8 @@ var _ = Describe("ASGs and Overlay Policy interaction", func() {
 			for _, sg := range testConfig.DefaultSecurityGroups {
 				Expect(cf.Cf("bind-running-security-group", sg).Wait(Timeout_Short)).To(gexec.Exit())
 			}
+			_, err := cfCLI.CleanupStaleNetworkPolicies()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("continues to enforce ASGs default deny", func() {

--- a/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
@@ -68,6 +68,8 @@ var _ = Describe("connectivity between containers on the overlay network", func(
 
 		AfterEach(func() {
 			Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
+			_, err := cfCLI.CleanupStaleNetworkPolicies()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("allows policies to whitelist traffic between applications", func(done Done) {

--- a/src/code.cloudfoundry.org/test/acceptance/policy_cleanup_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/policy_cleanup_test.go
@@ -35,6 +35,8 @@ var _ = Describe("policy cleanup", func() {
 
 	AfterEach(func() {
 		Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
+		_, err := cfCLI.CleanupStaleNetworkPolicies()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	Describe("policies/cleanup endpoint", func() {
@@ -51,7 +53,7 @@ var _ = Describe("policy cleanup", func() {
 			Expect(string(allPolicies)).Should(ContainSubstring(appAGuid))
 
 			By("cleaning up stale policies")
-			stalePolicies, err := cfCLI.Curl("POST", "/networking/v0/external/policies/cleanup", "")
+			stalePolicies, err := cfCLI.CleanupStaleNetworkPolicies()
 			Expect(string(stalePolicies)).ShouldNot(ContainSubstring(appAGuid))
 
 			By("checking that policy was not deleted")
@@ -63,7 +65,7 @@ var _ = Describe("policy cleanup", func() {
 			Expect(cfCLI.Delete(appA)).To(Succeed())
 
 			By("cleaning up stale policies")
-			stalePolicies, err = cfCLI.Curl("POST", "/networking/v0/external/policies/cleanup", "")
+			stalePolicies, err = cfCLI.CleanupStaleNetworkPolicies()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(stalePolicies)).Should(ContainSubstring(appAGuid))
 

--- a/src/code.cloudfoundry.org/test/acceptance/source_ip_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/source_ip_test.go
@@ -41,6 +41,8 @@ var _ = Describe("c2c traffic source ip", func() {
 	AfterEach(func() {
 		By("deleting the test org")
 		Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
+		_, err := cfCLI.CleanupStaleNetworkPolicies()
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should be the container's ip", func() {

--- a/src/code.cloudfoundry.org/test/acceptance/task_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/task_connectivity_test.go
@@ -54,6 +54,8 @@ var _ = Describe("task connectivity on the overlay network", func() {
 
 		AfterEach(func() {
 			Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
+			_, err := cfCLI.CleanupStaleNetworkPolicies()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("allows tasks to talk to app instances", func(done Done) {


### PR DESCRIPTION
### Steps to reproduce bug

There is a flake in cf-networking acceptance-tests related to c2c network-policy listing:
- most of the time when cleaning up tests, we delete orgs
- we do not specifically delete c2c network policies
- policy-server cleans those up every 60s when it sees things have been deleted from CAPI
- at least one check creates a policy and expects that to be the only policy present, which can fails due to the above time lag when test order is randomized.

### Fix
Remove stale policies in the after each.