### PR TITLE
Get rid of unnecessary Done channel

### DIFF
--- a/src/code.cloudfoundry.org/test/smoke/smoke_test.go
+++ b/src/code.cloudfoundry.org/test/smoke/smoke_test.go
@@ -58,7 +58,7 @@ var _ = Describe("connectivity between containers on the overlay network", func(
 			Expect(cf.Cf("delete-space", spaceName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
 		})
 
-		It("allows the user to configure policies", func(done Done) {
+		It("allows the user to configure policies", func() {
 			pushApp(appProxy, "proxy")
 			pushApp(appSmoke, "smoke", "--no-start")
 			setEnv(appSmoke, "PROXY_APP_URL", fmt.Sprintf("http://%s.%s", appProxy, config.AppsDomain))
@@ -94,8 +94,7 @@ var _ = Describe("connectivity between containers on the overlay network", func(
 				assertConnectionFails(appSmoke, appInstances)
 			})
 
-			close(done)
-		}, 30*60 /* <-- overall spec timeout in seconds */)
+		})
 	})
 })
 


### PR DESCRIPTION
We'd typically need to reimplement using hand-rolled channels in order to upgrade to ginkgo v2. However, in this case, everyone that could block or hang appears to be wrapped in a timeout already. So I opted to get rid of the done channel / timeout entirely