### PR TITLE
acceptance tests

### DIFF
--- a/src/code.cloudfoundry.org/test/acceptance/custom_iptables_compatibility_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/custom_iptables_compatibility_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Custom iptables compatibility", func() {
 	})
 
 	Describe("when a custom iptables rule is added and a new app is pushed", func() {
-		It("still applies the iptable rule to the new app", func() {
+		It("still applies the iptable rule to the new app", func(ctx SpecContext) {
 			By("checking that the app can reach the process running on the host")
 			session := cf.Cf("ssh", appName, "-c", "curl $CF_INSTANCE_IP:8898").Wait(10 * time.Second)
 			Eventually(session).Should(gexec.Exit(0))

--- a/src/code.cloudfoundry.org/test/acceptance/external_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/external_connectivity_test.go
@@ -103,7 +103,7 @@ var _ = Describe("external connectivity", func() {
 	}
 
 	Describe("basic (legacy) network behavior for an app", func() {
-		It("makes the app reachable from the router, and the app can reach the internet only if allowed", func() {
+		It("makes the app reachable from the router, and the app can reach the internet only if allowed", func(ctx SpecContext) {
 			By("checking that the app is reachable via the router")
 			Eventually(isReachable, "10s", "1s").Should(Succeed())
 			Consistently(isReachable, "2s", "0.5s").Should(Succeed())
@@ -144,7 +144,7 @@ var _ = Describe("external connectivity", func() {
 			Consistently(cannotProxy, "180s", "0.5s").Should(Succeed())
 		}, SpecTimeout(10*time.Minute))
 
-		It("allows outbound ICMP only if allowed", func() {
+		It("allows outbound ICMP only if allowed", func(ctx SpecContext) {
 			if testConfig.SkipICMPTests {
 				Skip("Test config has 'skip_icmp_test: true', skipping ICMP connectivity tests")
 			}

--- a/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
@@ -72,7 +72,7 @@ var _ = Describe("connectivity between containers on the overlay network", func(
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("allows policies to whitelist traffic between applications", func() {
+		It("allows policies to whitelist traffic between applications", func(ctx SpecContext) {
 			cmd := exec.Command("go", "run", "../../cf-pusher/cmd/cf-pusher/main.go", "--config", helpers.ConfigPath())
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr

--- a/src/code.cloudfoundry.org/test/acceptance/task_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/task_connectivity_test.go
@@ -58,7 +58,7 @@ var _ = Describe("task connectivity on the overlay network", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("allows tasks to talk to app instances", func() {
+		It("allows tasks to talk to app instances", func(ctx SpecContext) {
 			By("getting the overlay ip of proxy2")
 			cmd := exec.Command("curl", "--fail", proxy2+"."+domain)
 			sess, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)

--- a/src/code.cloudfoundry.org/test/scaling/scaling_test.go
+++ b/src/code.cloudfoundry.org/test/scaling/scaling_test.go
@@ -66,7 +66,7 @@ var _ = Describe("how the container network performs at scale", func() {
 			}
 		})
 		runScalingTest := func() {
-			It("allows the user to configure policies", func() {
+			It("allows the user to configure policies", func(ctx SpecContext) {
 				By(fmt.Sprintf("%s testing with %d source apps and %d destination apps listening on %d ports", ts(), testConfig.ProxyApplications, testConfig.Applications, len(ports)))
 				appIPs := getAppIPs(registryApp, tickApps)
 				conns := connections(proxyApps, appIPs, ports)


### PR DESCRIPTION
- Acceptance/Scaling Tests: Add SpecContext to It spec
- Change test for non-dynamic ASGs to use a sleep instead of Consistently because of intermittent connectivity issues
