### PR TITLE
fix: Update the security groups id data type from int to bigint

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
@@ -404,4 +404,8 @@ var MigrationsToPerform = PolicyServerMigrations{
 		Id: "74",
 		Up: migration_v0074,
 	},
+	PolicyServerMigration{
+		Id: "75",
+		Up: migration_v0075,
+	},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
@@ -2,8 +2,8 @@ package migrations
 
 var migration_v0075 = map[string][]string{
 	"mysql": []string{
-		`ALTER TABLE security_groups DROP FOREIGN KEY security_groups_pkey;`,
-		`ALTER TABLE security_groups ALTER COLUMN id type bigint;`,
+		`ALTER TABLE security_groups DROP PRIMARY KEY;`,
+		`ALTER TABLE security_groups MODIFY COLUMN id bigint;`,
 		`ALTER TABLE security_groups ADD PRIMARY KEY (id);`,
 	},
 	"postgres": []string{

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
@@ -2,14 +2,10 @@ package migrations
 
 var migration_v0075 = map[string][]string{
 	"mysql": []string{
-		`ALTER TABLE security_groups DROP PRIMARY KEY;`,
 		`ALTER TABLE security_groups MODIFY COLUMN id bigint;`,
-		`ALTER TABLE security_groups ADD PRIMARY KEY (id);`,
 	},
 	"postgres": []string{
-		`ALTER TABLE security_groups DROP CONSTRAINT security_groups_pkey;`,
 		`ALTER TABLE security_groups ALTER COLUMN id type bigint;`,
-		`ALTER TABLE security_groups ADD PRIMARY KEY (id);`,
 		`ALTER SEQUENCE public.security_groups_id_seq as bigint MAXVALUE 9223372036854775807;`,
 	},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0075.go
@@ -1,0 +1,15 @@
+package migrations
+
+var migration_v0075 = map[string][]string{
+	"mysql": []string{
+		`ALTER TABLE security_groups DROP FOREIGN KEY security_groups_pkey;`,
+		`ALTER TABLE security_groups ALTER COLUMN id type bigint;`,
+		`ALTER TABLE security_groups ADD PRIMARY KEY (id);`,
+	},
+	"postgres": []string{
+		`ALTER TABLE security_groups DROP CONSTRAINT security_groups_pkey;`,
+		`ALTER TABLE security_groups ALTER COLUMN id type bigint;`,
+		`ALTER TABLE security_groups ADD PRIMARY KEY (id);`,
+		`ALTER SEQUENCE public.security_groups_id_seq as bigint MAXVALUE 9223372036854775807;`,
+	},
+}


### PR DESCRIPTION
**Description of the change:**
We've faced some issues related to the creation of security groups and identified at the end that we've reached the limit of the up-counting primary key 'id' inside the security_groups table. The table was rolled out at [this](https://github.com/cloudfoundry/cf-networking-release/blob/develop/src/code.cloudfoundry.org/policy-server/store/migrations/v0067.go) update command and the column field ID was initialized with classical int. The limit of the data type SERIAL/ integer is on [PostgreSQL](https://www.postgresql.org/docs/current/datatype-numeric.html) (2147483647) and [MariaDB](https://mariadb.com/kb/en/int/#:~:text=Description,(SIGNED%20is%20the%20default).) (2147483647). We should use the same data type for IDs as on the other sequences → BIGSERIAL/ BIGINT. 

The PR handles the change as an update command of the database schema to mitigate the issue case. In general, would it be perfect, if there is a cleanup mechanism that recreates the IDs from time to time because the IDs are only (as far as I know) used for the pagination on the client side?

It would also follow the schema of the other tables to use the bigint data type.
![image (1)](https://github.com/cloudfoundry/cf-networking-release/assets/13447634/4bcefeb6-9ef4-4c6e-af0f-914911343e3b)

**TODO:**
- [ ] ~Check the update commands in general ([@]community I need support for this topic. Is necessary to also adjust the release notes? Is it necessary to add the update commands in any documentation or on more code lines?)~
- [x] Check the MySQL command
- [x] Add a description of why it's necessary to update the type
- [x] Test the commands on a PostgreSQL system
- [x] Test the commands on a MySQL system
- [ ] ~Test the fix on a PostgreSQL system~
- [ ] ~Test the fix on a MySQL system~