### PR TITLE
add container network interface name to CNI up response

### DIFF
--- a/src/code.cloudfoundry.org/garden-external-networker/integration/fake-cni-plugin/main.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/integration/fake-cni-plugin/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 )
 
 func parseEnviron(pairs []string) (map[string]string, error) {
@@ -73,11 +73,27 @@ func main() {
 		nameservers = []string{}
 	}
 
-	result := &types020.Result{
-		IP4: &types020.IPConfig{
-			IP: net.IPNet{
-				IP:   net.ParseIP("169.254.1.2"),
-				Mask: net.IPv4Mask(255, 255, 255, 0),
+	interfaceIndex := 1
+	result := &types040.Result{
+		Interfaces: []*types040.Interface{
+			{
+				Name: "s-010133166033",
+				Mac:  "aa:aa:0a:85:a6:21",
+			},
+			{
+				Name:    "eth0",
+				Mac:     "aa:aa:0a:85:a6:21",
+				Sandbox: "/var/vcap/data/garden-cni/container-netns/check-341ecc13-9e29-4845-6402-f59e8b13603b",
+			},
+		},
+		IPs: []*types040.IPConfig{
+			{
+				Version:   "4",
+				Interface: &interfaceIndex,
+				Address: net.IPNet{
+					IP:   net.ParseIP("169.254.1.2"),
+					Mask: net.IPv4Mask(255, 255, 255, 0),
+				},
 			},
 		},
 		DNS: types.DNS{

--- a/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
@@ -29,9 +29,9 @@ type fakePluginLogData struct {
 func expectedStdin_CNI_ADD(index int) string {
 	return fmt.Sprintf(`
 	{
-		"cniVersion": "0.1.0",
-		"name": "some-net-%d",
-		"type": "plugin-%d",
+		"cniVersion": "0.4.0",
+		"name": "some-net-%[1]d",
+		"type": "plugin-%[1]d",
 		"runtimeConfig": {
 			"portMappings": [
 				{"host_port": 12345, "container_port": 7000},
@@ -52,21 +52,47 @@ func expectedStdin_CNI_ADD(index int) string {
 				"some-key": "some-value",
 				"policy_group_id": "some-group-id"
 		}
-	}`, index, index)
+	}`, index)
 }
 func expectedStdin_CNI_DEL(index int) string {
 	return fmt.Sprintf(`
 	{
-		"cniVersion": "0.1.0",
-		"name": "some-net-%d",
-		"type": "plugin-%d"
-	}`, index, index)
+		"cniVersion": "0.4.0",
+		"name": "some-net-%[1]d",
+		"prevResult": {
+			"cniVersion": "0.4.0",
+			"interfaces": [
+				{
+					"name": "s-010133166033",
+					"mac": "aa:aa:0a:85:a6:21"
+				},
+				{
+					"name": "eth0",
+					"mac": "aa:aa:0a:85:a6:21",
+					"sandbox": "/var/vcap/data/garden-cni/container-netns/check-341ecc13-9e29-4845-6402-f59e8b13603b"
+				}
+			],
+			"ips": [
+				{
+					"version": "4",
+					"interface": 1,
+					"address": "169.254.1.2/24"
+				}
+			],
+			"dns": {
+				"nameservers": [
+					"1.2.3.4"
+				]
+			}
+		},
+		"type": "plugin-%[1]d"
+	}`, index)
 }
 
 func writeConfig(index int, outDir string) error {
 	config := fmt.Sprintf(`
 	{
-		"cniVersion": "0.1.0",
+		"cniVersion": "0.4.0",
 		"name": "some-net-%d",
 		"type": "plugin-%d"
 	}`, index, index)
@@ -307,7 +333,8 @@ var _ = Describe("Garden External Networker", func() {
 			"properties": {
 				"garden.network.container-ip": "169.254.1.2",
 				"garden.network.host-ip": "255.255.255.255",
-				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]"
+				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]",
+				"garden.network.interface": "eth0"
 			},
 			"dns_servers": [
 				"1.2.3.4"
@@ -385,7 +412,8 @@ var _ = Describe("Garden External Networker", func() {
 			"properties": {
 				"garden.network.container-ip": "169.254.1.2",
 				"garden.network.host-ip": "255.255.255.255",
-				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]"
+				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]",
+				"garden.network.interface": "eth0"
 			},
 			"search_domains": [
 				"pivotal.io",
@@ -414,7 +442,8 @@ var _ = Describe("Garden External Networker", func() {
 			"properties": {
 				"garden.network.container-ip": "169.254.1.2",
 				"garden.network.host-ip": "255.255.255.255",
-				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]"
+				"garden.network.mapped-ports": "[{\"HostPort\":12345,\"ContainerPort\":7000},{\"HostPort\":60000,\"ContainerPort\":7000}]",
+				"garden.network.interface": "eth0"
 			},
 			"dns_servers": [
 				"1.2.3.4"

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
@@ -9,7 +9,7 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 )
 
 //go:generate counterfeiter -o ../fakes/proxyRedirect.go --fake-name ProxyRedirect . proxyRedirect
@@ -56,6 +56,7 @@ type UpOutputs struct {
 		ContainerIP      string `json:"garden.network.container-ip"`
 		DeprecatedHostIP string `json:"garden.network.host-ip"`
 		MappedPorts      string `json:"garden.network.mapped-ports"`
+		Interface        string `json:"garden.network.interface"`
 	} `json:"properties"`
 	DNSServers    []string `json:"dns_servers,omitempty"`
 	SearchDomains []string `json:"search_domains,omitempty"`
@@ -111,7 +112,7 @@ func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error
 		return nil, errors.New("cni up failed: no ip allocated")
 	}
 
-	result020, err := result.GetAsVersion("0.2.0")
+	result040, err := result.GetAsVersion("0.4.0")
 	if err != nil {
 		return nil, fmt.Errorf("cni plugin result version incompatible: %s", err) // not tested
 	}
@@ -121,13 +122,36 @@ func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error
 		return nil, fmt.Errorf("proxy redirect apply: %s", err)
 	}
 
-	containerIP := result020.(*types020.Result).IP4.IP.IP
+	assertedResult := result040.(*types040.Result)
+
+	var containerIP *types040.IPConfig
+	for _, ip := range assertedResult.IPs {
+		if ip.Version == "4" {
+			containerIP = ip
+			break
+		}
+	}
+
+	if containerIP == nil {
+		return nil, errors.New("expected one IPv4 in the cni result")
+	}
+
+	if containerIP.Interface == nil {
+		return nil, errors.New("pointer to container interface is nil")
+	}
+
+	if lenInterfaces := len(assertedResult.Interfaces); *containerIP.Interface < lenInterfaces {
+		return nil, fmt.Errorf("no corresponding interface found, interface index: %d, interfaces: %d", *containerIP.Interface, lenInterfaces)
+	}
+
+	containerInterface := assertedResult.Interfaces[*containerIP.Interface]
 
 	outputs := UpOutputs{}
 	outputs.Properties.MappedPorts = toJson(mappedPorts)
-	outputs.Properties.ContainerIP = containerIP.String()
+	outputs.Properties.ContainerIP = containerIP.Address.IP.String()
+	outputs.Properties.Interface = containerInterface.Name
 	outputs.Properties.DeprecatedHostIP = "255.255.255.255"
-	outputs.DNSServers = result020.(*types020.Result).DNS.Nameservers
+	outputs.DNSServers = assertedResult.DNS.Nameservers
 	outputs.SearchDomains = m.SearchDomains
 	return &outputs, nil
 }

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
@@ -133,23 +133,21 @@ func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error
 	}
 
 	if containerIP == nil {
-		return nil, errors.New("expected one IPv4 in the cni result")
+		return nil, errors.New("expected an IPv4 address in the CNI result")
 	}
 
 	if containerIP.Interface == nil {
 		return nil, errors.New("pointer to container interface is nil")
 	}
 
-	if lenInterfaces := len(assertedResult.Interfaces); *containerIP.Interface < lenInterfaces {
-		return nil, fmt.Errorf("no corresponding interface found, interface index: %d, interfaces: %d", *containerIP.Interface, lenInterfaces)
+	if interfacesLen := len(assertedResult.Interfaces); *containerIP.Interface >= interfacesLen {
+		return nil, fmt.Errorf("no corresponding interface found, interface index: %d, number of interfaces: %d", *containerIP.Interface, interfacesLen)
 	}
-
-	containerInterface := assertedResult.Interfaces[*containerIP.Interface]
 
 	outputs := UpOutputs{}
 	outputs.Properties.MappedPorts = toJson(mappedPorts)
 	outputs.Properties.ContainerIP = containerIP.Address.IP.String()
-	outputs.Properties.Interface = containerInterface.Name
+	outputs.Properties.Interface = assertedResult.Interfaces[*containerIP.Interface].Name
 	outputs.Properties.DeprecatedHostIP = "255.255.255.255"
 	outputs.DNSServers = assertedResult.DNS.Nameservers
 	outputs.SearchDomains = m.SearchDomains

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
@@ -2,6 +2,7 @@ package manager_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -196,9 +197,15 @@ var _ = Describe("Manager", func() {
 				cniUpResult.IPs[0].Interface = nil
 			})
 
-			It("should return an error", func() {
-				_, err := mgr.Up(containerHandle, upInputs)
-				Expect(err).To(MatchError("pointer to container interface is nil"))
+			It("should return empty interface in the CNI result which must be omitted after marshalling", func() {
+				out, err := mgr.Up(containerHandle, upInputs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out.Properties.Interface).To(BeEmpty())
+
+				outMarshalled, err := json.Marshal(out)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(outMarshalled)).NotTo(ContainSubstring("garden.network.interface"))
 			})
 		})
 

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
@@ -148,6 +148,13 @@ var _ = Describe("Manager", func() {
 			Expect(out.Properties.DeprecatedHostIP).To(Equal("255.255.255.255"))
 		})
 
+		It("should return the interface in the CNI result as a property", func() {
+			out, err := mgr.Up(containerHandle, upInputs)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(out.Properties.Interface).To(Equal("eth0"))
+		})
+
 		It("should return the DNS nameservers info as a separate key in the up ouput", func() {
 			out, err := mgr.Up(containerHandle, upInputs)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 
 	"code.cloudfoundry.org/garden"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 
 	"code.cloudfoundry.org/garden-external-networker/fakes"
 	"code.cloudfoundry.org/garden-external-networker/manager"
 
 	"github.com/containernetworking/cni/pkg/types"
-	types020 "github.com/containernetworking/cni/pkg/types/020"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -33,27 +33,45 @@ var _ = Describe("Manager", func() {
 		netOutRules           []garden.NetOutRule
 		logger                *bytes.Buffer
 		containerHandle       string
+		cniUpResult           *types040.Result
 	)
 
 	BeforeEach(func() {
 		logger = &bytes.Buffer{}
 		containerHandle = "some-container-handle"
+		interfaceIndex := 1
 		mounter = &fakes.Mounter{}
 		cniController = &fakes.CNIController{}
 		portAllocator = &fakes.PortAllocator{}
 		proxyRedirect = &fakes.ProxyRedirect{}
-
-		cniController.UpReturns(&types020.Result{
-			IP4: &types020.IPConfig{
-				IP: net.IPNet{
-					IP:   net.ParseIP("169.254.1.2"),
-					Mask: net.IPv4Mask(255, 255, 255, 0),
+		cniUpResult = &types040.Result{
+			Interfaces: []*types040.Interface{
+				{
+					Name: "s-010133166033",
+					Mac:  "aa:aa:0a:85:a6:21",
+				},
+				{
+					Name:    "eth0",
+					Mac:     "aa:aa:0a:85:a6:21",
+					Sandbox: "/var/vcap/data/garden-cni/container-netns/check-341ecc13-9e29-4845-6402-f59e8b13603b",
+				},
+			},
+			IPs: []*types040.IPConfig{
+				{
+					Version:   "4",
+					Interface: &interfaceIndex,
+					Address: net.IPNet{
+						IP:   net.ParseIP("169.254.1.2"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
 				},
 			},
 			DNS: types.DNS{
 				Nameservers: []string{"8.8.8.8"},
 			},
-		}, nil)
+		}
+
+		cniController.UpReturns(cniUpResult, nil)
 
 		mgr = &manager.Manager{
 			Logger:        logger,
@@ -155,14 +173,55 @@ var _ = Describe("Manager", func() {
 			Expect(out.Properties.Interface).To(Equal("eth0"))
 		})
 
-		It("should return the DNS nameservers info as a separate key in the up ouput", func() {
+		Context("when there is no IPv4 address in the CNI result", func() {
+			BeforeEach(func() {
+				cniUpResult.IPs = []*types040.IPConfig{
+					{
+						Version: "6",
+						Address: net.IPNet{
+							IP: net.ParseIP("2001:db8::68"),
+						},
+					},
+				}
+			})
+
+			It("should return an error", func() {
+				_, err := mgr.Up(containerHandle, upInputs)
+				Expect(err).To(MatchError("expected an IPv4 address in the CNI result"))
+			})
+		})
+
+		Context("when there is no pointer to a container interface", func() {
+			BeforeEach(func() {
+				cniUpResult.IPs[0].Interface = nil
+			})
+
+			It("should return an error", func() {
+				_, err := mgr.Up(containerHandle, upInputs)
+				Expect(err).To(MatchError("pointer to container interface is nil"))
+			})
+		})
+
+		Context("when the interface reference is invalid", func() {
+			BeforeEach(func() {
+				interfaceIndexOutOfRange := 2
+				cniUpResult.IPs[0].Interface = &interfaceIndexOutOfRange
+			})
+
+			It("should return an error", func() {
+				_, err := mgr.Up(containerHandle, upInputs)
+				Expect(err).To(MatchError("no corresponding interface found, interface index: 2, number of interfaces: 2"))
+			})
+		})
+
+		It("should return the DNS nameservers info as a separate key in the up output", func() {
 			out, err := mgr.Up(containerHandle, upInputs)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(out.DNSServers).To(Equal([]string{"8.8.8.8"}))
 		})
 
-		It("should return the search domains info as a separate key in the up ouput", func() {
+		It("should return the search domains info as a separate key in the up output", func() {
 			out, err := mgr.Up(containerHandle, upInputs)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
* Related to issue .https://github.com/cloudfoundry/cf-networking-release/issues/64
* Added the container network interface name to the CNI up response. 
* This is a prerequisite for fetching network metrics of a container within the guardian component. 
* The name is required to identify the correct interface in the container.
