### PR TITLE
Enable proxy's `/dumprequest` endpoint to return headers

### DIFF
--- a/src/example-apps/proxy/README.md
+++ b/src/example-apps/proxy/README.md
@@ -106,6 +106,65 @@ X-Request-Start: 1600296938338
 X-Vcap-Request-Id: 2249e92a-fbc0-42e3-4d33-e341cd3969c8
 ```
 
+#### Optional param `returnHeaders`
+The Dump requests handler also takes an optional boolean query param
+`returnHeaders` that will, when `true`:
+- clone the headers sent to the proxy and add them to
+  the response headers
+- return two additional debug headers: `X-Proxy-Settable-Debug-Header` and
+  `X-Proxy-Immutable-Debug-Header`
+
+The value returned by proxy in the `X-Proxy-Settable-Debug-Header` will be
+copied from the original request's `X-Proxy-Settable-Debug-Header` header, if
+present. As it's name implies, `X-Proxy-Immutable-Debug-Header` cannot be
+configured and will *always* return the header with the same value.
+
+```bash
+$ curl -v -H 'X-Proxy-Settable-Debug-Header: potato' https://proxy.mydomain.com/dumprequest/?returnHeaders=true
+...
+> GET /dumprequest/?returnHeaders=true HTTP/1.1
+> Host: proxy.mydomain.com
+> User-Agent: curl/7.81.0
+> Accept: */*
+> X-Proxy-Settable-Debug-Header: potato 👈 Setting the debug header, sending to the proxy
+>
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< Accept: */*
+< B3: 6f098b875f6e433564f0077c97e0a08c-64f0077c97e0a08c
+< Content-Length: 572
+< Content-Type: text/plain; charset=utf-8
+< Date: Tue, 15 Aug 2023 23:36:52 GMT
+< User-Agent: curl/7.81.0
+< X-B3-Spanid: 64f0077c97e0a08c
+< X-B3-Traceid: 6f098b875f6e433564f0077c97e0a08c
+< X-Cf-Applicationid: 0b5e54c7-c9ad-4d3a-a0d3-0c351a77c3b2
+< X-Cf-Instanceid: 2ace08d0-1160-4159-7e8e-b8ec
+< X-Cf-Instanceindex: 0
+< X-Forwarded-For: 127.0.0.1
+< X-Forwarded-Proto: http
+< X-Proxy-Immutable-Debug-Header: default-immutable-value-from-within-proxy-src-code 👈 our immutable header is sent in the response
+< X-Proxy-Settable-Debug-Header: potato 👈 proxy is happy to send our debug header back, along with everything else
+< X-Request-Start: 1692142612239
+< X-Vcap-Request-Id: 6f098b87-5f6e-4335-64f0-077c97e0a08c
+<
+GET /dumprequest/?returnHeaders=true HTTP/1.1
+Host: proxy.mydomain.com
+Accept: */*
+B3: 6f098b875f6e433564f0077c97e0a08c-64f0077c97e0a08c
+User-Agent: curl/7.81.0
+X-B3-Spanid: 64f0077c97e0a08c
+X-B3-Traceid: 6f098b875f6e433564f0077c97e0a08c
+X-Cf-Applicationid: 0b5e54c7-c9ad-4d3a-a0d3-0c351a77c3b2
+X-Cf-Instanceid: 2ace08d0-1160-4159-7e8e-b8ec
+X-Cf-Instanceindex: 0
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-Proto: http
+X-Proxy-Settable-Debug-Header: potato 👈 the proxy instance received our configued debug header
+X-Request-Start: 1692142612239
+X-Vcap-Request-Id: 6f098b87-5f6e-4335-64f0-077c97e0a08c
+```
+
 ## `/echosourceip`
 
 [Echo source IP handler](./handlers/echo_source_ip_handler.go) responds with the

--- a/src/example-apps/proxy/handlers/dump_request_handler.go
+++ b/src/example-apps/proxy/handlers/dump_request_handler.go
@@ -10,5 +10,23 @@ type DumpRequestHandler struct {
 
 func (h *DumpRequestHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	reqBytes, _ := httputil.DumpRequest(req, false)
+
+	if returnHeadersParam := req.URL.Query().Get("returnHeaders"); returnHeadersParam == "true" {
+		originalHeaders := req.Header.Clone()
+		for name, values := range originalHeaders {
+			for _, v := range values {
+				resp.Header().Add(name, v)
+			}
+		}
+
+		// if X-Proxy-Settable-Debug-Header not in original request header, set default value
+		if h := originalHeaders.Get("X-Proxy-Settable-Debug-Header"); h == "" {
+			resp.Header().Set("X-Proxy-Settable-Debug-Header", "default-settable-value-from-within-proxy-src-code")
+		}
+
+		// We are going to explicitly set 'X-Proxy-Immutable-Debug-Header' at the end so it's immutable
+		resp.Header().Set("X-Proxy-Immutable-Debug-Header", "default-immutable-value-from-within-proxy-src-code")
+	}
+
 	resp.Write(reqBytes)
 }

--- a/src/example-apps/proxy/handlers/dump_request_handler_test.go
+++ b/src/example-apps/proxy/handlers/dump_request_handler_test.go
@@ -1,0 +1,98 @@
+package handlers_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"proxy/handlers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EchoSourceIPHandler", func() {
+	var (
+		handler *handlers.DumpRequestHandler
+		resp    *httptest.ResponseRecorder
+		req     *http.Request
+	)
+
+	BeforeEach(func() {
+		handler = &handlers.DumpRequestHandler{}
+		resp = httptest.NewRecorder()
+	})
+
+	Describe("GET", func() {
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest("GET", "/dumprequest", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns a body with a dump of the request", func() {
+			handler.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring("GET /dumprequest"))
+		})
+
+		It("does not send debug headers by default", func() {
+			handler.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(resp.Result().Header.Get("X-Proxy-Settable-Debug-Header")).To(BeEmpty())
+			Expect(resp.Result().Header.Get("X-Proxy-Immutable-Debug-Header")).To(BeEmpty())
+		})
+
+		Context("when the returnHeaders query param is 'true'", func() {
+			BeforeEach(func() {
+				var err error
+				req, err = http.NewRequest("GET", "/dumprequest?returnHeaders=true", nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Add("X-Random-Header", "apple")
+				req.Header.Add("X-Random-Header", "strawberry")
+				req.Header.Add("X-Random-Header", "guava")
+			})
+
+			It("returns headers for inspection", func() {
+				handler.ServeHTTP(resp, req)
+
+				By("returning the debug headers", func() {
+					Expect(resp.Code).To(Equal(http.StatusOK))
+					Expect(resp.Result().Header.Get("X-Proxy-Settable-Debug-Header")).To(Equal("default-settable-value-from-within-proxy-src-code"))
+					Expect(resp.Result().Header.Get("X-Proxy-Immutable-Debug-Header")).To(Equal("default-immutable-value-from-within-proxy-src-code"))
+				})
+
+				By("and cloning other headers sent from the client", func() {
+					Expect(resp.Code).To(Equal(http.StatusOK))
+
+					xRandomHeaderValues := resp.Result().Header.Values("X-Random-Header")
+					Expect(len(xRandomHeaderValues)).To(Equal(3))
+					Expect(xRandomHeaderValues).To(ContainElements("guava", "apple", "strawberry"))
+				})
+			})
+
+			Context("and the client sends an 'X-Proxy-Settable-Debug-Header' in their request", func() {
+				BeforeEach(func() {
+					var err error
+					req, err = http.NewRequest("GET", "/dumprequest?returnHeaders=true", nil)
+					req.Header.Add("X-Proxy-Settable-Debug-Header", "rutabaga")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("respects the value from the header and returns it", func() {
+					handler.ServeHTTP(resp, req)
+
+					Expect(resp.Code).To(Equal(http.StatusOK))
+					Expect(resp.Result().Header.Get("X-Proxy-Immutable-Debug-Header")).To(Equal("default-immutable-value-from-within-proxy-src-code"))
+
+					xProxySettabbleDebugHeaderValues := resp.Result().Header.Values("X-Proxy-Settable-Debug-Header")
+					Expect(len(xProxySettabbleDebugHeaderValues)).To(Equal(1))
+					Expect(xProxySettabbleDebugHeaderValues).To(ContainElement("rutabaga"))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
This commit adds a query param to the proxy's `/dumprequest` endpoint that adds two debug headers, `X-Proxy-Settable-Debug-Header` and `X-Proxy-Immutable-Debug-Header`,  and also copies the headers made to the proxy and sends them back in the response.

This is useful for checking how gorouter and other proxies handle forwarding and returning headers. I used this when I was working on acceptance for:
- https://github.com/cloudfoundry/gorouter/pull/356/files
- https://github.com/cloudfoundry/routing-release/pull/331