### PR TITLE
Reset-app-count-acceptance

### DIFF
--- a/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/inter_container_connectivity_test.go
@@ -67,6 +67,10 @@ var _ = Describe("connectivity between containers on the overlay network", func(
 		})
 
 		AfterEach(func() {
+			appsProxy = nil
+			appsTest = nil
+			ports = []int{8080}
+
 			Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
 			_, err := cfCLI.CleanupStaleNetworkPolicies()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The variable `appsTest` is incremented during test setup `BeforeEach()` for this acceptance test. The test asserts that the number of app instances according to `api/v1/instances` is the same number of app instances pushed. However, the number `len(appsTest)*appInstances` was incorrectly too large due to `appsTest` not being reset to zero between test runs (in the case of if a test failed and then re-tried.)

`appsProxy` and `ports` have not been causing test failures that we know of, but we are re-setting them here because they also get incremented as part of `BeforeEach()`.