### PR TITLE
Run integration tests with 1 node

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/bin/test.bash
+++ b/src/code.cloudfoundry.org/policy-server/bin/test.bash
@@ -9,4 +9,4 @@ configure_db "${DB}"
 args=${@} 
 go run github.com/onsi/ginkgo/v2/ginkgo  --skip-package integration,store $args
 # run integration and store package in serial
-go run github.com/onsi/ginkgo/v2/ginkgo $(echo $args | sed 's/-p //g') ./integration ./store
+go run github.com/onsi/ginkgo/v2/ginkgo $args --nodes=1 ./integration ./store


### PR DESCRIPTION
Arguments were changed from `-p` to `--nodes=7` and that broke the sed command. So instead specify `--nodes=1` to run integration test serially.

See:
- https://github.com/cloudfoundry/wg-app-platform-runtime-ci/commit/8aad1bef4b5f27d8cbe5bc842161d09978379141
- https://github.com/cloudfoundry/silk-release/commit/a9e5042fcd0694e6f9a53000fd3a981143df8c7c