### PR TITLE
fix(src/example-apps): Set GOVERSION to go1.21 for proxy app

### DIFF
--- a/src/example-apps/proxy/manifest.yml
+++ b/src/example-apps/proxy/manifest.yml
@@ -6,3 +6,4 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: proxy
+      GOVERSION: go1.21


### PR DESCRIPTION
We haven't tested this, recommend you do so if your pipelines don't do it for you.