### PR TITLE
Fix nil channel test

### DIFF
--- a/src/code.cloudfoundry.org/lib/poller/poller_test.go
+++ b/src/code.cloudfoundry.org/lib/poller/poller_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Poller", func() {
 			Consistently(retChan).ShouldNot(Receive())
 
 			signals <- os.Interrupt
-			Eventually(retChan).Should(Receive(nil))
+			Eventually(retChan).Should(Receive(BeNil()))
 		})
 
 		Context("when the cycle func errors", func() {
@@ -79,7 +79,7 @@ var _ = Describe("Poller", func() {
 				Consistently(retChan).ShouldNot(Receive())
 
 				signals <- os.Interrupt
-				Eventually(retChan).Should(Receive(nil))
+				Eventually(retChan).Should(Receive(BeNil()))
 			})
 		})
 	})

--- a/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
+++ b/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
@@ -124,7 +124,7 @@ var _ = Describe("ASGSyncer", func() {
 			Consistently(retChan).ShouldNot(Receive())
 
 			signals <- os.Interrupt
-			Eventually(retChan).Should(Receive(nil))
+			Eventually(retChan).Should(Receive(BeNil()))
 		})
 
 		Context("when the poller func errors", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Gomega changed matcher behavior:
https://github.com/onsi/gomega/releases/tag/v1.33.0


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
