### PR TITLE
Fixing issues with static check

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server-asg-syncer/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server-asg-syncer/main.go
@@ -69,7 +69,7 @@ func main() {
 		logger,
 	)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	securityGroupsStore := &store.SGStore{

--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server-internal/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server-internal/main.go
@@ -68,7 +68,7 @@ func main() {
 		logger,
 	)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	dataStore := store.New(

--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
@@ -117,7 +117,7 @@ func main() {
 		logger,
 	)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	logger.Info("db connection retrieved", lager.Data{})


### PR DESCRIPTION
```
cmd/policy-server-asg-syncer/main.go:72:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/policy-server-internal/main.go:71:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
cmd/policy-server/main.go:120:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
```

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
