### PR TITLE
Don't delete iptables.lock out from under other jobs when prestarting  garden-cni

### DIFF
--- a/jobs/garden-cni/templates/pre-start.erb
+++ b/jobs/garden-cni/templates/pre-start.erb
@@ -1,3 +1,4 @@
 #!/bin/bash -eu
 
-rm -rf /var/vcap/data/garden-cni || true
+rm -rf /var/vcap/data/garden-cni/container-netns || true
+rm -rf /var/vcap/data/garden-cni/external-networker-state.json || true


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Prevents garden-cni's pre-start from deleting the iptables.lock file out from under vxlan-policy-agent's pre-start script


Backward Compatibility
---------------
Breaking Change? no