### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/docs/11-3rd-party.md
+++ b/docs/11-3rd-party.md
@@ -393,10 +393,10 @@ None of silk-release communicates directly with CAPI. Information about ASGs are
 passed in on container creation.  If you want information about new ASGs that
 have been added through Cloud Controller, but that haven't been passed through
 on the config because the app has not been restarted, you can [poll
-CAPI](https://apidocs.cloudfoundry.org/280/security_groups/list_all_security_groups.html).
+CAPI](https://v3-apidocs.cloudfoundry.org/version/3.169.0/index.html#list-security-groups).
 
 If you want information on org, space, app events for use by your CNI plugin,
-see [the CF API docs](https://apidocs.cloudfoundry.org/280).
+see [the CF API docs](https://apidocs.cloudfoundry.org/).
 
 ### From Diego
 


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

~~The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.~~
`apidocs.cloudfoundry.org` has been converted to a redirect to `v3-apidocs.cloudfoundry.org`, so this change is needed to avoid incorrect links

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)