### PR TITLE
Address gosec rule G403

### DIFF
--- a/src/code.cloudfoundry.org/test-helpers/tls_helpers.go
+++ b/src/code.cloudfoundry.org/test-helpers/tls_helpers.go
@@ -58,7 +58,7 @@ func mapToX509Cert(PemEncodedCertFilePath string) []*x509.Certificate {
 }
 
 func buildCaFile() (string, *rsa.PrivateKey, error) {
-	privKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return "", nil, err
 	}
@@ -102,7 +102,6 @@ func buildCaFile() (string, *rsa.PrivateKey, error) {
 		Type:  "CERTIFICATE",
 		Bytes: caCert,
 	})
-
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR address gosec rule G403 stating RSA keys should be at least 2048 bits


Backward Compatibility
---------------
Breaking Change? **No**
