### PR TITLE
Containernetworking replace directive

### DIFF
--- a/src/code.cloudfoundry.org/garden-external-networker/fakes/cni_library.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/fakes/cni_library.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
 )
 
 type CNILibrary struct {
@@ -92,6 +93,32 @@ type CNILibrary struct {
 	delNetworkListReturnsOnCall map[int]struct {
 		result1 error
 	}
+	GCNetworkListStub        func(context.Context, *libcni.NetworkConfigList, *libcni.GCArgs) error
+	gCNetworkListMutex       sync.RWMutex
+	gCNetworkListArgsForCall []struct {
+		arg1 context.Context
+		arg2 *libcni.NetworkConfigList
+		arg3 *libcni.GCArgs
+	}
+	gCNetworkListReturns struct {
+		result1 error
+	}
+	gCNetworkListReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetCachedAttachmentsStub        func(string) ([]*libcni.NetworkAttachment, error)
+	getCachedAttachmentsMutex       sync.RWMutex
+	getCachedAttachmentsArgsForCall []struct {
+		arg1 string
+	}
+	getCachedAttachmentsReturns struct {
+		result1 []*libcni.NetworkAttachment
+		result2 error
+	}
+	getCachedAttachmentsReturnsOnCall map[int]struct {
+		result1 []*libcni.NetworkAttachment
+		result2 error
+	}
 	GetNetworkCachedConfigStub        func(*libcni.NetworkConfig, *libcni.RuntimeConf) ([]byte, *libcni.RuntimeConf, error)
 	getNetworkCachedConfigMutex       sync.RWMutex
 	getNetworkCachedConfigArgsForCall []struct {
@@ -150,6 +177,32 @@ type CNILibrary struct {
 	}
 	getNetworkListCachedResultReturnsOnCall map[int]struct {
 		result1 types.Result
+		result2 error
+	}
+	GetStatusNetworkListStub        func(context.Context, *libcni.NetworkConfigList) error
+	getStatusNetworkListMutex       sync.RWMutex
+	getStatusNetworkListArgsForCall []struct {
+		arg1 context.Context
+		arg2 *libcni.NetworkConfigList
+	}
+	getStatusNetworkListReturns struct {
+		result1 error
+	}
+	getStatusNetworkListReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetVersionInfoStub        func(context.Context, string) (version.PluginInfo, error)
+	getVersionInfoMutex       sync.RWMutex
+	getVersionInfoArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	getVersionInfoReturns struct {
+		result1 version.PluginInfo
+		result2 error
+	}
+	getVersionInfoReturnsOnCall map[int]struct {
+		result1 version.PluginInfo
 		result2 error
 	}
 	ValidateNetworkStub        func(context.Context, *libcni.NetworkConfig) ([]string, error)
@@ -568,6 +621,133 @@ func (fake *CNILibrary) DelNetworkListReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *CNILibrary) GCNetworkList(arg1 context.Context, arg2 *libcni.NetworkConfigList, arg3 *libcni.GCArgs) error {
+	fake.gCNetworkListMutex.Lock()
+	ret, specificReturn := fake.gCNetworkListReturnsOnCall[len(fake.gCNetworkListArgsForCall)]
+	fake.gCNetworkListArgsForCall = append(fake.gCNetworkListArgsForCall, struct {
+		arg1 context.Context
+		arg2 *libcni.NetworkConfigList
+		arg3 *libcni.GCArgs
+	}{arg1, arg2, arg3})
+	stub := fake.GCNetworkListStub
+	fakeReturns := fake.gCNetworkListReturns
+	fake.recordInvocation("GCNetworkList", []interface{}{arg1, arg2, arg3})
+	fake.gCNetworkListMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CNILibrary) GCNetworkListCallCount() int {
+	fake.gCNetworkListMutex.RLock()
+	defer fake.gCNetworkListMutex.RUnlock()
+	return len(fake.gCNetworkListArgsForCall)
+}
+
+func (fake *CNILibrary) GCNetworkListCalls(stub func(context.Context, *libcni.NetworkConfigList, *libcni.GCArgs) error) {
+	fake.gCNetworkListMutex.Lock()
+	defer fake.gCNetworkListMutex.Unlock()
+	fake.GCNetworkListStub = stub
+}
+
+func (fake *CNILibrary) GCNetworkListArgsForCall(i int) (context.Context, *libcni.NetworkConfigList, *libcni.GCArgs) {
+	fake.gCNetworkListMutex.RLock()
+	defer fake.gCNetworkListMutex.RUnlock()
+	argsForCall := fake.gCNetworkListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *CNILibrary) GCNetworkListReturns(result1 error) {
+	fake.gCNetworkListMutex.Lock()
+	defer fake.gCNetworkListMutex.Unlock()
+	fake.GCNetworkListStub = nil
+	fake.gCNetworkListReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CNILibrary) GCNetworkListReturnsOnCall(i int, result1 error) {
+	fake.gCNetworkListMutex.Lock()
+	defer fake.gCNetworkListMutex.Unlock()
+	fake.GCNetworkListStub = nil
+	if fake.gCNetworkListReturnsOnCall == nil {
+		fake.gCNetworkListReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.gCNetworkListReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CNILibrary) GetCachedAttachments(arg1 string) ([]*libcni.NetworkAttachment, error) {
+	fake.getCachedAttachmentsMutex.Lock()
+	ret, specificReturn := fake.getCachedAttachmentsReturnsOnCall[len(fake.getCachedAttachmentsArgsForCall)]
+	fake.getCachedAttachmentsArgsForCall = append(fake.getCachedAttachmentsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.GetCachedAttachmentsStub
+	fakeReturns := fake.getCachedAttachmentsReturns
+	fake.recordInvocation("GetCachedAttachments", []interface{}{arg1})
+	fake.getCachedAttachmentsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CNILibrary) GetCachedAttachmentsCallCount() int {
+	fake.getCachedAttachmentsMutex.RLock()
+	defer fake.getCachedAttachmentsMutex.RUnlock()
+	return len(fake.getCachedAttachmentsArgsForCall)
+}
+
+func (fake *CNILibrary) GetCachedAttachmentsCalls(stub func(string) ([]*libcni.NetworkAttachment, error)) {
+	fake.getCachedAttachmentsMutex.Lock()
+	defer fake.getCachedAttachmentsMutex.Unlock()
+	fake.GetCachedAttachmentsStub = stub
+}
+
+func (fake *CNILibrary) GetCachedAttachmentsArgsForCall(i int) string {
+	fake.getCachedAttachmentsMutex.RLock()
+	defer fake.getCachedAttachmentsMutex.RUnlock()
+	argsForCall := fake.getCachedAttachmentsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *CNILibrary) GetCachedAttachmentsReturns(result1 []*libcni.NetworkAttachment, result2 error) {
+	fake.getCachedAttachmentsMutex.Lock()
+	defer fake.getCachedAttachmentsMutex.Unlock()
+	fake.GetCachedAttachmentsStub = nil
+	fake.getCachedAttachmentsReturns = struct {
+		result1 []*libcni.NetworkAttachment
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CNILibrary) GetCachedAttachmentsReturnsOnCall(i int, result1 []*libcni.NetworkAttachment, result2 error) {
+	fake.getCachedAttachmentsMutex.Lock()
+	defer fake.getCachedAttachmentsMutex.Unlock()
+	fake.GetCachedAttachmentsStub = nil
+	if fake.getCachedAttachmentsReturnsOnCall == nil {
+		fake.getCachedAttachmentsReturnsOnCall = make(map[int]struct {
+			result1 []*libcni.NetworkAttachment
+			result2 error
+		})
+	}
+	fake.getCachedAttachmentsReturnsOnCall[i] = struct {
+		result1 []*libcni.NetworkAttachment
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CNILibrary) GetNetworkCachedConfig(arg1 *libcni.NetworkConfig, arg2 *libcni.RuntimeConf) ([]byte, *libcni.RuntimeConf, error) {
 	fake.getNetworkCachedConfigMutex.Lock()
 	ret, specificReturn := fake.getNetworkCachedConfigReturnsOnCall[len(fake.getNetworkCachedConfigArgsForCall)]
@@ -834,6 +1014,133 @@ func (fake *CNILibrary) GetNetworkListCachedResultReturnsOnCall(i int, result1 t
 	}{result1, result2}
 }
 
+func (fake *CNILibrary) GetStatusNetworkList(arg1 context.Context, arg2 *libcni.NetworkConfigList) error {
+	fake.getStatusNetworkListMutex.Lock()
+	ret, specificReturn := fake.getStatusNetworkListReturnsOnCall[len(fake.getStatusNetworkListArgsForCall)]
+	fake.getStatusNetworkListArgsForCall = append(fake.getStatusNetworkListArgsForCall, struct {
+		arg1 context.Context
+		arg2 *libcni.NetworkConfigList
+	}{arg1, arg2})
+	stub := fake.GetStatusNetworkListStub
+	fakeReturns := fake.getStatusNetworkListReturns
+	fake.recordInvocation("GetStatusNetworkList", []interface{}{arg1, arg2})
+	fake.getStatusNetworkListMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *CNILibrary) GetStatusNetworkListCallCount() int {
+	fake.getStatusNetworkListMutex.RLock()
+	defer fake.getStatusNetworkListMutex.RUnlock()
+	return len(fake.getStatusNetworkListArgsForCall)
+}
+
+func (fake *CNILibrary) GetStatusNetworkListCalls(stub func(context.Context, *libcni.NetworkConfigList) error) {
+	fake.getStatusNetworkListMutex.Lock()
+	defer fake.getStatusNetworkListMutex.Unlock()
+	fake.GetStatusNetworkListStub = stub
+}
+
+func (fake *CNILibrary) GetStatusNetworkListArgsForCall(i int) (context.Context, *libcni.NetworkConfigList) {
+	fake.getStatusNetworkListMutex.RLock()
+	defer fake.getStatusNetworkListMutex.RUnlock()
+	argsForCall := fake.getStatusNetworkListArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CNILibrary) GetStatusNetworkListReturns(result1 error) {
+	fake.getStatusNetworkListMutex.Lock()
+	defer fake.getStatusNetworkListMutex.Unlock()
+	fake.GetStatusNetworkListStub = nil
+	fake.getStatusNetworkListReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CNILibrary) GetStatusNetworkListReturnsOnCall(i int, result1 error) {
+	fake.getStatusNetworkListMutex.Lock()
+	defer fake.getStatusNetworkListMutex.Unlock()
+	fake.GetStatusNetworkListStub = nil
+	if fake.getStatusNetworkListReturnsOnCall == nil {
+		fake.getStatusNetworkListReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.getStatusNetworkListReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *CNILibrary) GetVersionInfo(arg1 context.Context, arg2 string) (version.PluginInfo, error) {
+	fake.getVersionInfoMutex.Lock()
+	ret, specificReturn := fake.getVersionInfoReturnsOnCall[len(fake.getVersionInfoArgsForCall)]
+	fake.getVersionInfoArgsForCall = append(fake.getVersionInfoArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetVersionInfoStub
+	fakeReturns := fake.getVersionInfoReturns
+	fake.recordInvocation("GetVersionInfo", []interface{}{arg1, arg2})
+	fake.getVersionInfoMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *CNILibrary) GetVersionInfoCallCount() int {
+	fake.getVersionInfoMutex.RLock()
+	defer fake.getVersionInfoMutex.RUnlock()
+	return len(fake.getVersionInfoArgsForCall)
+}
+
+func (fake *CNILibrary) GetVersionInfoCalls(stub func(context.Context, string) (version.PluginInfo, error)) {
+	fake.getVersionInfoMutex.Lock()
+	defer fake.getVersionInfoMutex.Unlock()
+	fake.GetVersionInfoStub = stub
+}
+
+func (fake *CNILibrary) GetVersionInfoArgsForCall(i int) (context.Context, string) {
+	fake.getVersionInfoMutex.RLock()
+	defer fake.getVersionInfoMutex.RUnlock()
+	argsForCall := fake.getVersionInfoArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *CNILibrary) GetVersionInfoReturns(result1 version.PluginInfo, result2 error) {
+	fake.getVersionInfoMutex.Lock()
+	defer fake.getVersionInfoMutex.Unlock()
+	fake.GetVersionInfoStub = nil
+	fake.getVersionInfoReturns = struct {
+		result1 version.PluginInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *CNILibrary) GetVersionInfoReturnsOnCall(i int, result1 version.PluginInfo, result2 error) {
+	fake.getVersionInfoMutex.Lock()
+	defer fake.getVersionInfoMutex.Unlock()
+	fake.GetVersionInfoStub = nil
+	if fake.getVersionInfoReturnsOnCall == nil {
+		fake.getVersionInfoReturnsOnCall = make(map[int]struct {
+			result1 version.PluginInfo
+			result2 error
+		})
+	}
+	fake.getVersionInfoReturnsOnCall[i] = struct {
+		result1 version.PluginInfo
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *CNILibrary) ValidateNetwork(arg1 context.Context, arg2 *libcni.NetworkConfig) ([]string, error) {
 	fake.validateNetworkMutex.Lock()
 	ret, specificReturn := fake.validateNetworkReturnsOnCall[len(fake.validateNetworkArgsForCall)]
@@ -979,6 +1286,10 @@ func (fake *CNILibrary) Invocations() map[string][][]interface{} {
 	defer fake.delNetworkMutex.RUnlock()
 	fake.delNetworkListMutex.RLock()
 	defer fake.delNetworkListMutex.RUnlock()
+	fake.gCNetworkListMutex.RLock()
+	defer fake.gCNetworkListMutex.RUnlock()
+	fake.getCachedAttachmentsMutex.RLock()
+	defer fake.getCachedAttachmentsMutex.RUnlock()
 	fake.getNetworkCachedConfigMutex.RLock()
 	defer fake.getNetworkCachedConfigMutex.RUnlock()
 	fake.getNetworkCachedResultMutex.RLock()
@@ -987,6 +1298,10 @@ func (fake *CNILibrary) Invocations() map[string][][]interface{} {
 	defer fake.getNetworkListCachedConfigMutex.RUnlock()
 	fake.getNetworkListCachedResultMutex.RLock()
 	defer fake.getNetworkListCachedResultMutex.RUnlock()
+	fake.getStatusNetworkListMutex.RLock()
+	defer fake.getStatusNetworkListMutex.RUnlock()
+	fake.getVersionInfoMutex.RLock()
+	defer fake.getVersionInfoMutex.RUnlock()
 	fake.validateNetworkMutex.RLock()
 	defer fake.validateNetworkMutex.RUnlock()
 	fake.validateNetworkListMutex.RLock()

--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -6,8 +6,6 @@ toolchain go1.22.3
 
 replace (
 	example-apps/spammer => ../example-apps/spammer
-	github.com/containernetworking/cni => github.com/containernetworking/cni v1.1.2
-	github.com/containernetworking/plugins => github.com/containernetworking/plugins v1.1.1
 
 	github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.1.1-0.20180411231007-da89364d9d43
 	github.com/nats-io/go-nats => github.com/nats-io/go-nats v1.5.1-0.20180331191609-247b2a84d8d0
@@ -81,6 +79,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
 	github.com/square/certstrap v1.3.0 // indirect
+	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.step.sm/crypto v0.51.2 // indirect
 	golang.org/x/crypto v0.26.0 // indirect

--- a/src/code.cloudfoundry.org/go.sum
+++ b/src/code.cloudfoundry.org/go.sum
@@ -681,10 +681,10 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/containernetworking/cni v1.1.2 h1:wtRGZVv7olUHMOqouPpn3cXJWpJgM6+EUl31EQbXALQ=
-github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
-github.com/containernetworking/plugins v1.1.1 h1:+AGfFigZ5TiQH00vhR8qPeSatj53eNGz0C1d3wVYlHE=
-github.com/containernetworking/plugins v1.1.1/go.mod h1:Sr5TH/eBsGLXK/h71HeLfX19sZPp3ry5uHSkI4LPxV8=
+github.com/containernetworking/cni v1.2.3 h1:hhOcjNVUQTnzdRJ6alC5XF+wd9mfGIUaj8FuJbEslXM=
+github.com/containernetworking/cni v1.2.3/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
+github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=
+github.com/containernetworking/plugins v1.5.1/go.mod h1:MIQfgMayGuHYs0XdNudf31cLLAC+i242hNm6KuDGqCM=
 github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
 github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -1012,6 +1012,8 @@ github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26 h1:mWCRvpoEMVlslxEvvp
 github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26/go.mod h1:0uD3VMXkZ7Bw0ojGCwDzebBBzPBXtzEZeXai+56BLX4=
 github.com/tedsuo/rata v1.0.0 h1:Sf9aZrYy6ElSTncjnGkyC2yuVvz5YJetBIUKJ4CmeKE=
 github.com/tedsuo/rata v1.0.0/go.mod h1:X47ELzhOoLbfFIY0Cql9P6yo3Cdwf2CMX3FVZxRzJPc=
+github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/libcni/api.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/libcni/api.go
@@ -15,7 +15,7 @@
 package libcni
 
 // Note this is the actual implementation of the CNI specification, which
-// is reflected in the https://github.com/containernetworking/cni/blob/master/SPEC.md file
+// is reflected in the SPEC.md file.
 // it is typically bundled into runtime providers (i.e. containerd or cri-o would use this
 // before calling runc or hcsshim).  It is also bundled into CNI providers as well, for example,
 // to add an IP to a container, to parse the configuration of the CNI and so on.
@@ -23,10 +23,11 @@ package libcni
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -38,6 +39,8 @@ import (
 
 var (
 	CacheDir = "/var/lib/cni"
+	// slightly awkward wording to preserve anyone matching on error strings
+	ErrorCheckNotSupp = fmt.Errorf("does not support the CHECK command")
 )
 
 const (
@@ -73,8 +76,23 @@ type NetworkConfigList struct {
 	Name         string
 	CNIVersion   string
 	DisableCheck bool
+	DisableGC    bool
 	Plugins      []*NetworkConfig
 	Bytes        []byte
+}
+
+type NetworkAttachment struct {
+	ContainerID    string
+	Network        string
+	IfName         string
+	Config         []byte
+	NetNS          string
+	CniArgs        [][2]string
+	CapabilityArgs map[string]interface{}
+}
+
+type GCArgs struct {
+	ValidAttachments []types.GCAttachment
 }
 
 type CNI interface {
@@ -92,6 +110,13 @@ type CNI interface {
 
 	ValidateNetworkList(ctx context.Context, net *NetworkConfigList) ([]string, error)
 	ValidateNetwork(ctx context.Context, net *NetworkConfig) ([]string, error)
+
+	GCNetworkList(ctx context.Context, net *NetworkConfigList, args *GCArgs) error
+	GetStatusNetworkList(ctx context.Context, net *NetworkConfigList) error
+
+	GetCachedAttachments(containerID string) ([]*NetworkAttachment, error)
+
+	GetVersionInfo(ctx context.Context, pluginType string) (version.PluginInfo, error)
 }
 
 type CNIConfig struct {
@@ -139,8 +164,11 @@ func buildOneConfig(name, cniVersion string, orig *NetworkConfig, prevResult typ
 	if err != nil {
 		return nil, err
 	}
+	if rt != nil {
+		return injectRuntimeConfig(orig, rt)
+	}
 
-	return injectRuntimeConfig(orig, rt)
+	return orig, nil
 }
 
 // This function takes a libcni RuntimeConf structure and injects values into
@@ -195,6 +223,7 @@ type cachedInfo struct {
 	Config         []byte                 `json:"config"`
 	IfName         string                 `json:"ifName"`
 	NetworkName    string                 `json:"networkName"`
+	NetNS          string                 `json:"netns,omitempty"`
 	CniArgs        [][2]string            `json:"cniArgs,omitempty"`
 	CapabilityArgs map[string]interface{} `json:"capabilityArgs,omitempty"`
 	RawResult      map[string]interface{} `json:"result,omitempty"`
@@ -229,6 +258,7 @@ func (c *CNIConfig) cacheAdd(result types.Result, config []byte, netName string,
 		Config:         config,
 		IfName:         rt.IfName,
 		NetworkName:    netName,
+		NetNS:          rt.NetNS,
 		CniArgs:        rt.Args,
 		CapabilityArgs: rt.CapabilityArgs,
 	}
@@ -254,11 +284,11 @@ func (c *CNIConfig) cacheAdd(result types.Result, config []byte, netName string,
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(fname), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fname), 0o700); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(fname, newBytes, 0600)
+	return os.WriteFile(fname, newBytes, 0o600)
 }
 
 func (c *CNIConfig) cacheDel(netName string, rt *RuntimeConf) error {
@@ -277,7 +307,7 @@ func (c *CNIConfig) getCachedConfig(netName string, rt *RuntimeConf) ([]byte, *R
 	if err != nil {
 		return nil, nil, err
 	}
-	bytes, err = ioutil.ReadFile(fname)
+	bytes, err = os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil, nil
@@ -305,7 +335,7 @@ func (c *CNIConfig) getLegacyCachedResult(netName, cniVersion string, rt *Runtim
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(fname)
+	data, err := os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil
@@ -333,7 +363,7 @@ func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf)
 	if err != nil {
 		return nil, err
 	}
-	fdata, err := ioutil.ReadFile(fname)
+	fdata, err := os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil
@@ -388,6 +418,68 @@ func (c *CNIConfig) GetNetworkListCachedConfig(list *NetworkConfigList, rt *Runt
 // RuntimeConf with fields updated with info from the cached Config.
 func (c *CNIConfig) GetNetworkCachedConfig(net *NetworkConfig, rt *RuntimeConf) ([]byte, *RuntimeConf, error) {
 	return c.getCachedConfig(net.Network.Name, rt)
+}
+
+// GetCachedAttachments returns a list of network attachments from the cache.
+// The returned list will be filtered by the containerID if the value is not empty.
+func (c *CNIConfig) GetCachedAttachments(containerID string) ([]*NetworkAttachment, error) {
+	dirPath := filepath.Join(c.getCacheDir(&RuntimeConf{}), "results")
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	fileNames := make([]string, 0, len(entries))
+	for _, e := range entries {
+		fileNames = append(fileNames, e.Name())
+	}
+	sort.Strings(fileNames)
+
+	attachments := []*NetworkAttachment{}
+	for _, fname := range fileNames {
+		if len(containerID) > 0 {
+			part := fmt.Sprintf("-%s-", containerID)
+			pos := strings.Index(fname, part)
+			if pos <= 0 || pos+len(part) >= len(fname) {
+				continue
+			}
+		}
+
+		cacheFile := filepath.Join(dirPath, fname)
+		bytes, err := os.ReadFile(cacheFile)
+		if err != nil {
+			continue
+		}
+
+		cachedInfo := cachedInfo{}
+
+		if err := json.Unmarshal(bytes, &cachedInfo); err != nil {
+			continue
+		}
+		if cachedInfo.Kind != CNICacheV1 {
+			continue
+		}
+		if len(containerID) > 0 && cachedInfo.ContainerID != containerID {
+			continue
+		}
+		if cachedInfo.IfName == "" || cachedInfo.NetworkName == "" {
+			continue
+		}
+
+		attachments = append(attachments, &NetworkAttachment{
+			ContainerID:    cachedInfo.ContainerID,
+			Network:        cachedInfo.NetworkName,
+			IfName:         cachedInfo.IfName,
+			Config:         cachedInfo.Config,
+			NetNS:          cachedInfo.NetNS,
+			CniArgs:        cachedInfo.CniArgs,
+			CapabilityArgs: cachedInfo.CapabilityArgs,
+		})
+	}
+	return attachments, nil
 }
 
 func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (types.Result, error) {
@@ -453,7 +545,7 @@ func (c *CNIConfig) CheckNetworkList(ctx context.Context, list *NetworkConfigLis
 	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
 		return err
 	} else if !gtet {
-		return fmt.Errorf("configuration version %q does not support the CHECK command", list.CNIVersion)
+		return fmt.Errorf("configuration version %q %w", list.CNIVersion, ErrorCheckNotSupp)
 	}
 
 	if list.DisableCheck {
@@ -497,9 +589,9 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
 		return err
 	} else if gtet {
-		cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt)
-		if err != nil {
-			return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
+		if cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt); err != nil {
+			_ = c.cacheDel(list.Name, rt)
+			cachedResult = nil
 		}
 	}
 
@@ -509,6 +601,7 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 			return fmt.Errorf("plugin %s failed (delete): %w", pluginDescription(net.Network), err)
 		}
 	}
+
 	_ = c.cacheDel(list.Name, rt)
 
 	return nil
@@ -547,7 +640,7 @@ func (c *CNIConfig) CheckNetwork(ctx context.Context, net *NetworkConfig, rt *Ru
 	if gtet, err := version.GreaterThanOrEqualTo(net.Network.CNIVersion, "0.4.0"); err != nil {
 		return err
 	} else if !gtet {
-		return fmt.Errorf("configuration version %q does not support the CHECK command", net.Network.CNIVersion)
+		return fmt.Errorf("configuration version %q %w", net.Network.CNIVersion, ErrorCheckNotSupp)
 	}
 
 	cachedResult, err := c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
@@ -664,6 +757,129 @@ func (c *CNIConfig) GetVersionInfo(ctx context.Context, pluginType string) (vers
 	}
 
 	return invoke.GetVersionInfo(ctx, pluginPath, c.exec)
+}
+
+// GCNetworkList will do two things
+// - dump the list of cached attachments, and issue deletes as necessary
+// - issue a GC to the underlying plugins (if the version is high enough)
+func (c *CNIConfig) GCNetworkList(ctx context.Context, list *NetworkConfigList, args *GCArgs) error {
+	// If DisableGC is set, then don't bother GCing at all.
+	if list.DisableGC {
+		return nil
+	}
+
+	// First, get the list of cached attachments
+	cachedAttachments, err := c.GetCachedAttachments("")
+	if err != nil {
+		return nil
+	}
+
+	var validAttachments map[types.GCAttachment]interface{}
+	if args != nil {
+		validAttachments = make(map[types.GCAttachment]interface{}, len(args.ValidAttachments))
+		for _, a := range args.ValidAttachments {
+			validAttachments[a] = nil
+		}
+	}
+
+	var errs []error
+
+	for _, cachedAttachment := range cachedAttachments {
+		if cachedAttachment.Network != list.Name {
+			continue
+		}
+		// we found this attachment
+		gca := types.GCAttachment{
+			ContainerID: cachedAttachment.ContainerID,
+			IfName:      cachedAttachment.IfName,
+		}
+		if _, ok := validAttachments[gca]; ok {
+			continue
+		}
+		// otherwise, this attachment wasn't valid and we should issue a CNI DEL
+		rt := RuntimeConf{
+			ContainerID:    cachedAttachment.ContainerID,
+			NetNS:          cachedAttachment.NetNS,
+			IfName:         cachedAttachment.IfName,
+			Args:           cachedAttachment.CniArgs,
+			CapabilityArgs: cachedAttachment.CapabilityArgs,
+		}
+		if err := c.DelNetworkList(ctx, list, &rt); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete stale attachment %s %s: %w", rt.ContainerID, rt.IfName, err))
+		}
+	}
+
+	// now, if the version supports it, issue a GC
+	if gt, _ := version.GreaterThanOrEqualTo(list.CNIVersion, "1.1.0"); gt {
+		inject := map[string]interface{}{
+			"name":       list.Name,
+			"cniVersion": list.CNIVersion,
+		}
+		if args != nil {
+			inject["cni.dev/valid-attachments"] = args.ValidAttachments
+			// #1101: spec used incorrect variable name
+			inject["cni.dev/attachments"] = args.ValidAttachments
+		}
+
+		for _, plugin := range list.Plugins {
+			// build config here
+			pluginConfig, err := InjectConf(plugin, inject)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to generate configuration to GC plugin %s: %w", plugin.Network.Type, err))
+			}
+			if err := c.gcNetwork(ctx, pluginConfig); err != nil {
+				errs = append(errs, fmt.Errorf("failed to GC plugin %s: %w", plugin.Network.Type, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c *CNIConfig) gcNetwork(ctx context.Context, net *NetworkConfig) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return err
+	}
+	args := c.args("GC", &RuntimeConf{})
+
+	return invoke.ExecPluginWithoutResult(ctx, pluginPath, net.Bytes, args, c.exec)
+}
+
+func (c *CNIConfig) GetStatusNetworkList(ctx context.Context, list *NetworkConfigList) error {
+	// If the version doesn't support status, abort.
+	if gt, _ := version.GreaterThanOrEqualTo(list.CNIVersion, "1.1.0"); !gt {
+		return nil
+	}
+
+	inject := map[string]interface{}{
+		"name":       list.Name,
+		"cniVersion": list.CNIVersion,
+	}
+
+	for _, plugin := range list.Plugins {
+		// build config here
+		pluginConfig, err := InjectConf(plugin, inject)
+		if err != nil {
+			return fmt.Errorf("failed to generate configuration to get plugin STATUS %s: %w", plugin.Network.Type, err)
+		}
+		if err := c.getStatusNetwork(ctx, pluginConfig); err != nil {
+			return err // Don't collect errors here, so we return a clean error code.
+		}
+	}
+	return nil
+}
+
+func (c *CNIConfig) getStatusNetwork(ctx context.Context, net *NetworkConfig) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return err
+	}
+	args := c.args("STATUS", &RuntimeConf{})
+
+	return invoke.ExecPluginWithoutResult(ctx, pluginPath, net.Bytes, args, c.exec)
 }
 
 // =====

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/libcni/conf.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/libcni/conf.go
@@ -16,13 +16,16 @@ package libcni
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
 )
 
 type NotFoundError struct {
@@ -54,7 +57,7 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 }
 
 func ConfFromFile(filename string) (*NetworkConfig, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
@@ -85,17 +88,89 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 		}
 	}
 
-	disableCheck := false
-	if rawDisableCheck, ok := rawList["disableCheck"]; ok {
-		disableCheck, ok = rawDisableCheck.(bool)
+	rawVersions, ok := rawList["cniVersions"]
+	if ok {
+		// Parse the current package CNI version
+		rvs, ok := rawVersions.([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("error parsing configuration list: invalid disableCheck type %T", rawDisableCheck)
+			return nil, fmt.Errorf("error parsing configuration list: invalid type for cniVersions: %T", rvs)
 		}
+		vs := make([]string, 0, len(rvs))
+		for i, rv := range rvs {
+			v, ok := rv.(string)
+			if !ok {
+				return nil, fmt.Errorf("error parsing configuration list: invalid type for cniVersions index %d: %T", i, rv)
+			}
+			gt, err := version.GreaterThan(v, version.Current())
+			if err != nil {
+				return nil, fmt.Errorf("error parsing configuration list: invalid cniVersions entry %s at index %d: %w", v, i, err)
+			} else if !gt {
+				// Skip versions "greater" than this implementation of the spec
+				vs = append(vs, v)
+			}
+		}
+
+		// if cniVersion was already set, append it to the list for sorting.
+		if cniVersion != "" {
+			gt, err := version.GreaterThan(cniVersion, version.Current())
+			if err != nil {
+				return nil, fmt.Errorf("error parsing configuration list: invalid cniVersion %s: %w", cniVersion, err)
+			} else if !gt {
+				// ignore any versions higher than the current implemented spec version
+				vs = append(vs, cniVersion)
+			}
+		}
+		slices.SortFunc[[]string](vs, func(v1, v2 string) int {
+			if v1 == v2 {
+				return 0
+			}
+			if gt, _ := version.GreaterThan(v1, v2); gt {
+				return 1
+			}
+			return -1
+		})
+		if len(vs) > 0 {
+			cniVersion = vs[len(vs)-1]
+		}
+	}
+
+	readBool := func(key string) (bool, error) {
+		rawVal, ok := rawList[key]
+		if !ok {
+			return false, nil
+		}
+		if b, ok := rawVal.(bool); ok {
+			return b, nil
+		}
+
+		s, ok := rawVal.(string)
+		if !ok {
+			return false, fmt.Errorf("error parsing configuration list: invalid type %T for %s", rawVal, key)
+		}
+		s = strings.ToLower(s)
+		switch s {
+		case "false":
+			return false, nil
+		case "true":
+			return true, nil
+		}
+		return false, fmt.Errorf("error parsing configuration list: invalid value %q for %s", s, key)
+	}
+
+	disableCheck, err := readBool("disableCheck")
+	if err != nil {
+		return nil, err
+	}
+
+	disableGC, err := readBool("disableGC")
+	if err != nil {
+		return nil, err
 	}
 
 	list := &NetworkConfigList{
 		Name:         name,
 		DisableCheck: disableCheck,
+		DisableGC:    disableGC,
 		CNIVersion:   cniVersion,
 		Bytes:        bytes,
 	}
@@ -129,7 +204,7 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 }
 
 func ConfListFromFile(filename string) (*NetworkConfigList, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
@@ -138,7 +213,7 @@ func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 
 func ConfFiles(dir string, extensions []string) ([]string, error) {
 	// In part, adapted from rkt/networking/podenv.go#listFiles
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	switch {
 	case err == nil: // break
 	case os.IsNotExist(err):
@@ -206,7 +281,8 @@ func LoadConfList(dir, name string) (*NetworkConfigList, error) {
 	singleConf, err := LoadConf(dir, name)
 	if err != nil {
 		// A little extra logic so the error makes sense
-		if _, ok := err.(NoConfigsFoundError); len(files) != 0 && ok {
+		var ncfErr NoConfigsFoundError
+		if len(files) != 0 && errors.As(err, &ncfErr) {
 			// Config lists found but no config files found
 			return nil, NotFoundError{dir, name}
 		}

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
@@ -51,25 +51,34 @@ func DelegateAdd(ctx context.Context, delegatePlugin string, netconf []byte, exe
 // DelegateCheck calls the given delegate plugin with the CNI CHECK action and
 // JSON configuration
 func DelegateCheck(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	return delegateNoResult(ctx, delegatePlugin, netconf, exec, "CHECK")
+}
+
+func delegateNoResult(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec, verb string) error {
 	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
 	if err != nil {
 		return err
 	}
 
-	// DelegateCheck will override the original CNI_COMMAND env from process with CHECK
-	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("CHECK"), realExec)
+	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs(verb), realExec)
 }
 
 // DelegateDel calls the given delegate plugin with the CNI DEL action and
 // JSON configuration
 func DelegateDel(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
-	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
-	if err != nil {
-		return err
-	}
+	return delegateNoResult(ctx, delegatePlugin, netconf, exec, "DEL")
+}
 
-	// DelegateDel will override the original CNI_COMMAND env from process with DEL
-	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("DEL"), realExec)
+// DelegateStatus calls the given delegate plugin with the CNI STATUS action and
+// JSON configuration
+func DelegateStatus(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	return delegateNoResult(ctx, delegatePlugin, netconf, exec, "STATUS")
+}
+
+// DelegateGC calls the given delegate plugin with the CNI GC action and
+// JSON configuration
+func DelegateGC(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	return delegateNoResult(ctx, delegatePlugin, netconf, exec, "GC")
 }
 
 // return CNIArgs used by delegation

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
@@ -81,17 +81,17 @@ func fixupResultVersion(netconf, result []byte) (string, []byte, error) {
 // object to ExecPluginWithResult() to verify the incoming stdin and environment
 // and provide a tailored response:
 //
-//import (
+// import (
 //	"encoding/json"
 //	"path"
 //	"strings"
-//)
+// )
 //
-//type fakeExec struct {
+// type fakeExec struct {
 //	version.PluginDecoder
-//}
+// }
 //
-//func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+// func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
 //	net := &types.NetConf{}
 //	err := json.Unmarshal(stdinData, net)
 //	if err != nil {
@@ -109,14 +109,14 @@ func fixupResultVersion(netconf, result []byte) (string, []byte, error) {
 //		}
 //	}
 //	return []byte("{\"CNIVersion\":\"0.4.0\"}"), nil
-//}
+// }
 //
-//func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+// func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
 //	if len(paths) > 0 {
 //		return path.Join(paths[0], plugin), nil
 //	}
 //	return "", fmt.Errorf("failed to find plugin %s in paths %v", plugin, paths)
-//}
+// }
 
 func ExecPluginWithResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) (types.Result, error) {
 	if exec == nil {

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package invoke

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_darwin.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CNI authors
+// Copyright 2022 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package ns
 
-import "errors"
+import "github.com/containernetworking/cni/pkg/types"
 
-// BadReader is an io.Reader which always errors
-type BadReader struct {
-	Error error
-}
-
-func (r *BadReader) Read(_ []byte) (int, error) {
-	if r.Error != nil {
-		return 0, r.Error
-	}
-	return 0, errors.New("banana")
-}
-
-func (r *BadReader) Close() error {
-	return nil
+func CheckNetNS(nsPath string) (bool, *types.Error) {
+	return false, nil
 }

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_linux.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_linux.go
@@ -1,0 +1,50 @@
+// Copyright 2022 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ns
+
+import (
+	"runtime"
+
+	"github.com/vishvananda/netns"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// Returns an object representing the current OS thread's network namespace
+func getCurrentNS() (netns.NsHandle, error) {
+	// Lock the thread in case other goroutine executes in it and changes its
+	// network namespace after getCurrentThreadNetNSPath(), otherwise it might
+	// return an unexpected network namespace.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	return netns.Get()
+}
+
+func CheckNetNS(nsPath string) (bool, *types.Error) {
+	ns, err := netns.GetFromPath(nsPath)
+	// Let plugins check whether nsPath from args is valid. Also support CNI DEL for empty nsPath as already-deleted nsPath.
+	if err != nil {
+		return false, nil
+	}
+	defer ns.Close()
+
+	pluginNS, err := getCurrentNS()
+	if err != nil {
+		return false, types.NewError(types.ErrInvalidNetNS, "get plugin's netns failed", "")
+	}
+	defer pluginNS.Close()
+
+	return pluginNS.Equal(ns), nil
+}

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_windows.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/ns/ns_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2016 CNI authors
+// Copyright 2022 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testutils
+package ns
 
-import "errors"
+import "github.com/containernetworking/cni/pkg/types"
 
-// BadReader is an io.Reader which always errors
-type BadReader struct {
-	Error error
-}
-
-func (r *BadReader) Read(_ []byte) (int, error) {
-	if r.Error != nil {
-		return 0, r.Error
-	}
-	return 0, errors.New("banana")
-}
-
-func (r *BadReader) Close() error {
-	return nil
+func CheckNetNS(nsPath string) (bool, *types.Error) {
+	return false, nil
 }

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/skel/skel.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/skel/skel.go
@@ -19,13 +19,14 @@ package skel
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 
+	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/utils"
 	"github.com/containernetworking/cni/pkg/version"
@@ -34,12 +35,13 @@ import (
 // CmdArgs captures all the arguments passed in to the plugin
 // via both env vars and stdin
 type CmdArgs struct {
-	ContainerID string
-	Netns       string
-	IfName      string
-	Args        string
-	Path        string
-	StdinData   []byte
+	ContainerID   string
+	Netns         string
+	IfName        string
+	Args          string
+	Path          string
+	NetnsOverride string
+	StdinData     []byte
 }
 
 type dispatcher struct {
@@ -55,21 +57,25 @@ type dispatcher struct {
 type reqForCmdEntry map[string]bool
 
 func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
-	var cmd, contID, netns, ifName, args, path string
+	var cmd, contID, netns, ifName, args, path, netnsOverride string
 
 	vars := []struct {
-		name      string
-		val       *string
-		reqForCmd reqForCmdEntry
+		name       string
+		val        *string
+		reqForCmd  reqForCmdEntry
+		validateFn func(string) *types.Error
 	}{
 		{
 			"CNI_COMMAND",
 			&cmd,
 			reqForCmdEntry{
-				"ADD":   true,
-				"CHECK": true,
-				"DEL":   true,
+				"ADD":    true,
+				"CHECK":  true,
+				"DEL":    true,
+				"GC":     true,
+				"STATUS": true,
 			},
+			nil,
 		},
 		{
 			"CNI_CONTAINERID",
@@ -79,6 +85,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 				"CHECK": true,
 				"DEL":   true,
 			},
+			utils.ValidateContainerID,
 		},
 		{
 			"CNI_NETNS",
@@ -88,6 +95,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 				"CHECK": true,
 				"DEL":   false,
 			},
+			nil,
 		},
 		{
 			"CNI_IFNAME",
@@ -97,6 +105,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 				"CHECK": true,
 				"DEL":   true,
 			},
+			utils.ValidateInterfaceName,
 		},
 		{
 			"CNI_ARGS",
@@ -106,15 +115,29 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 				"CHECK": false,
 				"DEL":   false,
 			},
+			nil,
 		},
 		{
 			"CNI_PATH",
 			&path,
 			reqForCmdEntry{
-				"ADD":   true,
-				"CHECK": true,
-				"DEL":   true,
+				"ADD":    true,
+				"CHECK":  true,
+				"DEL":    true,
+				"GC":     true,
+				"STATUS": true,
 			},
+			nil,
+		},
+		{
+			"CNI_NETNS_OVERRIDE",
+			&netnsOverride,
+			reqForCmdEntry{
+				"ADD":   false,
+				"CHECK": false,
+				"DEL":   false,
+			},
+			nil,
 		},
 	}
 
@@ -124,6 +147,10 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 		if *v.val == "" {
 			if v.reqForCmd[cmd] || v.name == "CNI_COMMAND" {
 				argsMissing = append(argsMissing, v.name)
+			}
+		} else if v.reqForCmd[cmd] && v.validateFn != nil {
+			if err := v.validateFn(*v.val); err != nil {
+				return "", nil, err
 			}
 		}
 	}
@@ -137,18 +164,25 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 		t.Stdin = bytes.NewReader(nil)
 	}
 
-	stdinData, err := ioutil.ReadAll(t.Stdin)
+	stdinData, err := io.ReadAll(t.Stdin)
 	if err != nil {
 		return "", nil, types.NewError(types.ErrIOFailure, fmt.Sprintf("error reading from stdin: %v", err), "")
 	}
 
+	if cmd != "VERSION" {
+		if err := validateConfig(stdinData); err != nil {
+			return "", nil, err
+		}
+	}
+
 	cmdArgs := &CmdArgs{
-		ContainerID: contID,
-		Netns:       netns,
-		IfName:      ifName,
-		Args:        args,
-		Path:        path,
-		StdinData:   stdinData,
+		ContainerID:   contID,
+		Netns:         netns,
+		IfName:        ifName,
+		Args:          args,
+		Path:          path,
+		StdinData:     stdinData,
+		NetnsOverride: netnsOverride,
 	}
 	return cmd, cmdArgs, nil
 }
@@ -163,8 +197,13 @@ func (t *dispatcher) checkVersionAndCall(cmdArgs *CmdArgs, pluginVersionInfo ver
 		return types.NewError(types.ErrIncompatibleCNIVersion, "incompatible CNI versions", verErr.Details())
 	}
 
+	if toCall == nil {
+		return nil
+	}
+
 	if err = toCall(cmdArgs); err != nil {
-		if e, ok := err.(*types.Error); ok {
+		var e *types.Error
+		if errors.As(err, &e) {
 			// don't wrap Error in Error
 			return e
 		}
@@ -190,7 +229,7 @@ func validateConfig(jsonBytes []byte) *types.Error {
 	return nil
 }
 
-func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+func (t *dispatcher) pluginMain(funcs CNIFuncs, versionInfo version.PluginInfo, about string) *types.Error {
 	cmd, cmdArgs, err := t.getCmdArgsFromEnv()
 	if err != nil {
 		// Print the about string to stderr when no command is set
@@ -202,21 +241,20 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error,
 		return err
 	}
 
-	if cmd != "VERSION" {
-		if err = validateConfig(cmdArgs.StdinData); err != nil {
-			return err
-		}
-		if err = utils.ValidateContainerID(cmdArgs.ContainerID); err != nil {
-			return err
-		}
-		if err = utils.ValidateInterfaceName(cmdArgs.IfName); err != nil {
-			return err
-		}
-	}
-
 	switch cmd {
 	case "ADD":
-		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdAdd)
+		err = t.checkVersionAndCall(cmdArgs, versionInfo, funcs.Add)
+		if err != nil {
+			return err
+		}
+		if strings.ToUpper(cmdArgs.NetnsOverride) != "TRUE" && cmdArgs.NetnsOverride != "1" {
+			isPluginNetNS, checkErr := ns.CheckNetNS(cmdArgs.Netns)
+			if checkErr != nil {
+				return checkErr
+			} else if isPluginNetNS {
+				return types.NewError(types.ErrInvalidNetNS, "plugin's netns and netns from CNI_NETNS should not be the same", "")
+			}
+		}
 	case "CHECK":
 		configVersion, err := t.ConfVersionDecoder.Decode(cmdArgs.StdinData)
 		if err != nil {
@@ -232,7 +270,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error,
 			if err != nil {
 				return types.NewError(types.ErrDecodingFailure, err.Error(), "")
 			} else if gtet {
-				if err := t.checkVersionAndCall(cmdArgs, versionInfo, cmdCheck); err != nil {
+				if err := t.checkVersionAndCall(cmdArgs, versionInfo, funcs.Check); err != nil {
 					return err
 				}
 				return nil
@@ -240,7 +278,62 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error,
 		}
 		return types.NewError(types.ErrIncompatibleCNIVersion, "plugin version does not allow CHECK", "")
 	case "DEL":
-		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdDel)
+		err = t.checkVersionAndCall(cmdArgs, versionInfo, funcs.Del)
+		if err != nil {
+			return err
+		}
+		if strings.ToUpper(cmdArgs.NetnsOverride) != "TRUE" && cmdArgs.NetnsOverride != "1" {
+			isPluginNetNS, checkErr := ns.CheckNetNS(cmdArgs.Netns)
+			if checkErr != nil {
+				return checkErr
+			} else if isPluginNetNS {
+				return types.NewError(types.ErrInvalidNetNS, "plugin's netns and netns from CNI_NETNS should not be the same", "")
+			}
+		}
+	case "GC":
+		configVersion, err := t.ConfVersionDecoder.Decode(cmdArgs.StdinData)
+		if err != nil {
+			return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+		}
+		if gtet, err := version.GreaterThanOrEqualTo(configVersion, "1.1.0"); err != nil {
+			return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+		} else if !gtet {
+			return types.NewError(types.ErrIncompatibleCNIVersion, "config version does not allow GC", "")
+		}
+		for _, pluginVersion := range versionInfo.SupportedVersions() {
+			gtet, err := version.GreaterThanOrEqualTo(pluginVersion, configVersion)
+			if err != nil {
+				return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+			} else if gtet {
+				if err := t.checkVersionAndCall(cmdArgs, versionInfo, funcs.GC); err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+		return types.NewError(types.ErrIncompatibleCNIVersion, "plugin version does not allow GC", "")
+	case "STATUS":
+		configVersion, err := t.ConfVersionDecoder.Decode(cmdArgs.StdinData)
+		if err != nil {
+			return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+		}
+		if gtet, err := version.GreaterThanOrEqualTo(configVersion, "1.1.0"); err != nil {
+			return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+		} else if !gtet {
+			return types.NewError(types.ErrIncompatibleCNIVersion, "config version does not allow STATUS", "")
+		}
+		for _, pluginVersion := range versionInfo.SupportedVersions() {
+			gtet, err := version.GreaterThanOrEqualTo(pluginVersion, configVersion)
+			if err != nil {
+				return types.NewError(types.ErrDecodingFailure, err.Error(), "")
+			} else if gtet {
+				if err := t.checkVersionAndCall(cmdArgs, versionInfo, funcs.Status); err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+		return types.NewError(types.ErrIncompatibleCNIVersion, "plugin version does not allow STATUS", "")
 	case "VERSION":
 		if err := versionInfo.Encode(t.Stdout); err != nil {
 			return types.NewError(types.ErrIOFailure, err.Error(), "")
@@ -264,13 +357,63 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error,
 //
 // To let this package automatically handle errors and call os.Exit(1) for you,
 // use PluginMain() instead.
+//
+// Deprecated: Use github.com/containernetworking/cni/pkg/skel.PluginMainFuncsWithError instead.
 func PluginMainWithError(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+	return PluginMainFuncsWithError(CNIFuncs{Add: cmdAdd, Check: cmdCheck, Del: cmdDel}, versionInfo, about)
+}
+
+// CNIFuncs contains a group of callback command funcs to be passed in as
+// parameters to the core "main" for a plugin.
+type CNIFuncs struct {
+	Add    func(_ *CmdArgs) error
+	Del    func(_ *CmdArgs) error
+	Check  func(_ *CmdArgs) error
+	GC     func(_ *CmdArgs) error
+	Status func(_ *CmdArgs) error
+}
+
+// PluginMainFuncsWithError is the core "main" for a plugin. It accepts
+// callback functions defined within CNIFuncs and returns an error.
+//
+// The caller must also specify what CNI spec versions the plugin supports.
+//
+// It is the responsibility of the caller to check for non-nil error return.
+//
+// For a plugin to comply with the CNI spec, it must print any error to stdout
+// as JSON and then exit with nonzero status code.
+//
+// To let this package automatically handle errors and call os.Exit(1) for you,
+// use PluginMainFuncs() instead.
+func PluginMainFuncsWithError(funcs CNIFuncs, versionInfo version.PluginInfo, about string) *types.Error {
 	return (&dispatcher{
 		Getenv: os.Getenv,
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-	}).pluginMain(cmdAdd, cmdCheck, cmdDel, versionInfo, about)
+	}).pluginMain(funcs, versionInfo, about)
+}
+
+// PluginMainFuncs is the core "main" for a plugin which includes automatic error handling.
+// This is a newer alternative func to PluginMain which abstracts CNI commands within a
+// CNIFuncs interface.
+//
+// The caller must also specify what CNI spec versions the plugin supports.
+//
+// The caller can specify an "about" string, which is printed on stderr
+// when no CNI_COMMAND is specified. The recommended output is "CNI plugin <foo> v<version>"
+//
+// When an error occurs in any func in CNIFuncs, PluginMainFuncs will print the error
+// as JSON to stdout and call os.Exit(1).
+//
+// To have more control over error handling, use PluginMainFuncsWithError() instead.
+func PluginMainFuncs(funcs CNIFuncs, versionInfo version.PluginInfo, about string) {
+	if e := PluginMainFuncsWithError(funcs, versionInfo, about); e != nil {
+		if err := e.Print(); err != nil {
+			log.Print("Error writing error JSON to stdout: ", err)
+		}
+		os.Exit(1)
+	}
 }
 
 // PluginMain is the core "main" for a plugin which includes automatic error handling.
@@ -284,6 +427,8 @@ func PluginMainWithError(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versio
 // as JSON to stdout and call os.Exit(1).
 //
 // To have more control over error handling, use PluginMainWithError() instead.
+//
+// Deprecated: Use github.com/containernetworking/cni/pkg/skel.PluginMainFuncs instead.
 func PluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) {
 	if e := PluginMainWithError(cmdAdd, cmdCheck, cmdDel, versionInfo, about); e != nil {
 		if err := e.Print(); err != nil {

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/types/args.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/types/args.go
@@ -26,8 +26,8 @@ import (
 type UnmarshallableBool bool
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-// Returns boolean true if the string is "1" or "[Tt]rue"
-// Returns boolean false if the string is "0" or "[Ff]alse"
+// Returns boolean true if the string is "1" or "true" or "True"
+// Returns boolean false if the string is "0" or "false" or "False”
 func (b *UnmarshallableBool) UnmarshalText(data []byte) error {
 	s := strings.ToLower(string(data))
 	switch s {

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/types/create/create.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/types/create/create.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/types"
+	_ "github.com/containernetworking/cni/pkg/types/020"
+	_ "github.com/containernetworking/cni/pkg/types/040"
+	_ "github.com/containernetworking/cni/pkg/types/100"
 	convert "github.com/containernetworking/cni/pkg/types/internal"
 )
 

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/utils/utils.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/utils/utils.go
@@ -36,7 +36,6 @@ var cniReg = regexp.MustCompile(`^` + cniValidNameChars + `*$`)
 
 // ValidateContainerID will validate that the supplied containerID is not empty does not contain invalid characters
 func ValidateContainerID(containerID string) *types.Error {
-
 	if containerID == "" {
 		return types.NewError(types.ErrUnknownContainer, "missing containerID", "")
 	}
@@ -48,7 +47,6 @@ func ValidateContainerID(containerID string) *types.Error {
 
 // ValidateNetworkName will validate that the supplied networkName does not contain invalid characters
 func ValidateNetworkName(networkName string) *types.Error {
-
 	if networkName == "" {
 		return types.NewError(types.ErrInvalidNetworkConfig, "missing network name:", "")
 	}
@@ -58,11 +56,11 @@ func ValidateNetworkName(networkName string) *types.Error {
 	return nil
 }
 
-// ValidateInterfaceName will validate the interface name based on the three rules below
+// ValidateInterfaceName will validate the interface name based on the four rules below
 // 1. The name must not be empty
 // 2. The name must be less than 16 characters
 // 3. The name must not be "." or ".."
-// 3. The name must not contain / or : or any whitespace characters
+// 4. The name must not contain / or : or any whitespace characters
 // ref to https://github.com/torvalds/linux/blob/master/net/core/dev.c#L1024
 func ValidateInterfaceName(ifName string) *types.Error {
 	if len(ifName) == 0 {

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
@@ -142,3 +142,27 @@ func GreaterThanOrEqualTo(version, otherVersion string) (bool, error) {
 	}
 	return false, nil
 }
+
+// GreaterThan returns true if the first version is greater than the second
+func GreaterThan(version, otherVersion string) (bool, error) {
+	firstMajor, firstMinor, firstMicro, err := ParseVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	secondMajor, secondMinor, secondMicro, err := ParseVersion(otherVersion)
+	if err != nil {
+		return false, err
+	}
+
+	if firstMajor > secondMajor {
+		return true, nil
+	} else if firstMajor == secondMajor {
+		if firstMinor > secondMinor {
+			return true, nil
+		} else if firstMinor == secondMinor && firstMicro > secondMicro {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/version/version.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/cni/pkg/version/version.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/types"
-	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 // Current reports the version of the CNI spec implemented by this library
 func Current() string {
-	return types100.ImplementedSpecVersion
+	return "1.1.0"
 }
 
 // Legacy PluginInfo describes a plugin that is backwards compatible with the
@@ -35,8 +34,10 @@ func Current() string {
 //
 // Any future CNI spec versions which meet this definition should be added to
 // this list.
-var Legacy = PluginSupports("0.1.0", "0.2.0")
-var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0")
+var (
+	Legacy = PluginSupports("0.1.0", "0.2.0")
+	All    = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0")
+)
 
 // VersionsFrom returns a list of versions starting from min, inclusive
 func VersionsStartingFrom(min string) PluginInfo {

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/plugins/pkg/testutils/dns.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/plugins/pkg/testutils/dns.go
@@ -16,7 +16,6 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -28,7 +27,7 @@ import (
 // an error if any occurs while creating/writing the file. It is the caller's
 // responsibility to remove the file.
 func TmpResolvConf(dnsConf types.DNS) (string, error) {
-	f, err := ioutil.TempFile("", "cni_test_resolv.conf")
+	f, err := os.CreateTemp("", "cni_test_resolv.conf")
 	if err != nil {
 		return "", fmt.Errorf("failed to get temp file for CNI test resolv.conf: %v", err)
 	}

--- a/src/code.cloudfoundry.org/vendor/github.com/containernetworking/plugins/pkg/testutils/netns_linux.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/containernetworking/plugins/pkg/testutils/netns_linux.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/containernetworking/plugins/pkg/ns"
 	"golang.org/x/sys/unix"
+
+	"github.com/containernetworking/plugins/pkg/ns"
 )
 
 func getNsRunDir() string {
@@ -49,7 +50,6 @@ func getNsRunDir() string {
 // Creates a new persistent (bind-mounted) network namespace and returns an object
 // representing that namespace, without switching to it.
 func NewNS() (ns.NetNS, error) {
-
 	nsRunDir := getNsRunDir()
 
 	b := make([]byte, 16)
@@ -61,7 +61,7 @@ func NewNS() (ns.NetNS, error) {
 	// Create the directory for mounting network namespaces
 	// This needs to be a shared mountpoint in case it is mounted in to
 	// other namespaces (containers)
-	err = os.MkdirAll(nsRunDir, 0755)
+	err = os.MkdirAll(nsRunDir, 0o755)
 	if err != nil {
 		return nil, err
 	}

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/.golangci.yml
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/LICENSE
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/LICENSE
@@ -1,0 +1,192 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014 Vishvananda Ishaya.
+   Copyright 2014 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/README.md
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/README.md
@@ -1,0 +1,51 @@
+# netns - network namespaces in go #
+
+The netns package provides an ultra-simple interface for handling
+network namespaces in go. Changing namespaces requires elevated
+privileges, so in most cases this code needs to be run as root.
+
+## Local Build and Test ##
+
+You can use go get command:
+
+    go get github.com/vishvananda/netns
+
+Testing (requires root):
+
+    sudo -E go test github.com/vishvananda/netns
+
+## Example ##
+
+```go
+package main
+
+import (
+    "fmt"
+    "net"
+    "runtime"
+
+    "github.com/vishvananda/netns"
+)
+
+func main() {
+    // Lock the OS Thread so we don't accidentally switch namespaces
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+
+    // Save the current network namespace
+    origns, _ := netns.Get()
+    defer origns.Close()
+
+    // Create a new network namespace
+    newns, _ := netns.New()
+    defer newns.Close()
+
+    // Do something with the network namespace
+    ifaces, _ := net.Interfaces()
+    fmt.Printf("Interfaces: %v\n", ifaces)
+
+    // Switch back to the original namespace
+    netns.Set(origns)
+}
+
+```

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/doc.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/doc.go
@@ -1,0 +1,9 @@
+// Package netns allows ultra-simple network namespace handling. NsHandles
+// can be retrieved and set. Note that the current namespace is thread
+// local so actions that set and reset namespaces should use LockOSThread
+// to make sure the namespace doesn't change due to a goroutine switch.
+// It is best to close NsHandles when you are done with them. This can be
+// accomplished via a `defer ns.Close()` on the handle. Changing namespaces
+// requires elevated privileges, so in most cases this code needs to be run
+// as root.
+package netns

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -1,0 +1,283 @@
+package netns
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// Deprecated: use golang.org/x/sys/unix pkg instead.
+const (
+	CLONE_NEWUTS  = unix.CLONE_NEWUTS  /* New utsname group? */
+	CLONE_NEWIPC  = unix.CLONE_NEWIPC  /* New ipcs */
+	CLONE_NEWUSER = unix.CLONE_NEWUSER /* New user namespace */
+	CLONE_NEWPID  = unix.CLONE_NEWPID  /* New pid namespace */
+	CLONE_NEWNET  = unix.CLONE_NEWNET  /* New network namespace */
+	CLONE_IO      = unix.CLONE_IO      /* Get io context */
+)
+
+const bindMountPath = "/run/netns" /* Bind mount path for named netns */
+
+// Setns sets namespace using golang.org/x/sys/unix.Setns.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
+func Setns(ns NsHandle, nstype int) (err error) {
+	return unix.Setns(int(ns), nstype)
+}
+
+// Set sets the current network namespace to the namespace represented
+// by NsHandle.
+func Set(ns NsHandle) (err error) {
+	return unix.Setns(int(ns), unix.CLONE_NEWNET)
+}
+
+// New creates a new network namespace, sets it as current and returns
+// a handle to it.
+func New() (ns NsHandle, err error) {
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		return -1, err
+	}
+	return Get()
+}
+
+// NewNamed creates a new named network namespace, sets it as current,
+// and returns a handle to it
+func NewNamed(name string) (NsHandle, error) {
+	if _, err := os.Stat(bindMountPath); os.IsNotExist(err) {
+		err = os.MkdirAll(bindMountPath, 0755)
+		if err != nil {
+			return None(), err
+		}
+	}
+
+	newNs, err := New()
+	if err != nil {
+		return None(), err
+	}
+
+	namedPath := path.Join(bindMountPath, name)
+
+	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0444)
+	if err != nil {
+		newNs.Close()
+		return None(), err
+	}
+	f.Close()
+
+	nsPath := fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
+	err = unix.Mount(nsPath, namedPath, "bind", unix.MS_BIND, "")
+	if err != nil {
+		newNs.Close()
+		return None(), err
+	}
+
+	return newNs, nil
+}
+
+// DeleteNamed deletes a named network namespace
+func DeleteNamed(name string) error {
+	namedPath := path.Join(bindMountPath, name)
+
+	err := unix.Unmount(namedPath, unix.MNT_DETACH)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(namedPath)
+}
+
+// Get gets a handle to the current threads network namespace.
+func Get() (NsHandle, error) {
+	return GetFromThread(os.Getpid(), unix.Gettid())
+}
+
+// GetFromPath gets a handle to a network namespace
+// identified by the path
+func GetFromPath(path string) (NsHandle, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, err
+	}
+	return NsHandle(fd), nil
+}
+
+// GetFromName gets a handle to a named network namespace such as one
+// created by `ip netns add`.
+func GetFromName(name string) (NsHandle, error) {
+	return GetFromPath(filepath.Join(bindMountPath, name))
+}
+
+// GetFromPid gets a handle to the network namespace of a given pid.
+func GetFromPid(pid int) (NsHandle, error) {
+	return GetFromPath(fmt.Sprintf("/proc/%d/ns/net", pid))
+}
+
+// GetFromThread gets a handle to the network namespace of a given pid and tid.
+func GetFromThread(pid, tid int) (NsHandle, error) {
+	return GetFromPath(fmt.Sprintf("/proc/%d/task/%d/ns/net", pid, tid))
+}
+
+// GetFromDocker gets a handle to the network namespace of a docker container.
+// Id is prefixed matched against the running docker containers, so a short
+// identifier can be used as long as it isn't ambiguous.
+func GetFromDocker(id string) (NsHandle, error) {
+	pid, err := getPidForContainer(id)
+	if err != nil {
+		return -1, err
+	}
+	return GetFromPid(pid)
+}
+
+// borrowed from docker/utils/utils.go
+func findCgroupMountpoint(cgroupType string) (int, string, error) {
+	output, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return -1, "", err
+	}
+
+	// /proc/mounts has 6 fields per line, one mount per line, e.g.
+	// cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.Split(line, " ")
+		if len(parts) == 6 {
+			switch parts[2] {
+			case "cgroup2":
+				return 2, parts[1], nil
+			case "cgroup":
+				for _, opt := range strings.Split(parts[3], ",") {
+					if opt == cgroupType {
+						return 1, parts[1], nil
+					}
+				}
+			}
+		}
+	}
+
+	return -1, "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
+}
+
+// Returns the relative path to the cgroup docker is running in.
+// borrowed from docker/utils/utils.go
+// modified to get the docker pid instead of using /proc/self
+func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
+	if err != nil {
+		return "", err
+	}
+	result := strings.Split(string(dockerpid), "\n")
+	if len(result) == 0 || len(result[0]) == 0 {
+		return "", fmt.Errorf("docker pid not found in /var/run/docker.pid")
+	}
+	pid, err := strconv.Atoi(result[0])
+	if err != nil {
+		return "", err
+	}
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.Split(line, ":")
+		// any type used by docker should work
+		if (cgroupVer == 1 && parts[1] == cgroupType) ||
+			(cgroupVer == 2 && parts[1] == "") {
+			return parts[2], nil
+		}
+	}
+	return "", fmt.Errorf("cgroup '%s' not found in /proc/%d/cgroup", cgroupType, pid)
+}
+
+// Returns the first pid in a container.
+// borrowed from docker/utils/utils.go
+// modified to only return the first pid
+// modified to glob with id
+// modified to search for newer docker containers
+// modified to look for cgroups v2
+func getPidForContainer(id string) (int, error) {
+	pid := 0
+
+	// memory is chosen randomly, any cgroup used by docker works
+	cgroupType := "memory"
+
+	cgroupVer, cgroupRoot, err := findCgroupMountpoint(cgroupType)
+	if err != nil {
+		return pid, err
+	}
+
+	cgroupDocker, err := getDockerCgroup(cgroupVer, cgroupType)
+	if err != nil {
+		return pid, err
+	}
+
+	id += "*"
+
+	var pidFile string
+	if cgroupVer == 1 {
+		pidFile = "tasks"
+	} else if cgroupVer == 2 {
+		pidFile = "cgroup.procs"
+	} else {
+		return -1, fmt.Errorf("Invalid cgroup version '%d'", cgroupVer)
+	}
+
+	attempts := []string{
+		filepath.Join(cgroupRoot, cgroupDocker, id, pidFile),
+		// With more recent lxc versions use, cgroup will be in lxc/
+		filepath.Join(cgroupRoot, cgroupDocker, "lxc", id, pidFile),
+		// With more recent docker, cgroup will be in docker/
+		filepath.Join(cgroupRoot, cgroupDocker, "docker", id, pidFile),
+		// Even more recent docker versions under systemd use docker-<id>.scope/
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", pidFile),
+		// Even more recent docker versions under cgroup/systemd/docker/<id>/
+		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, pidFile),
+		// Kubernetes with docker and CNI is even more different. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "pod*", id, pidFile),
+		// Another flavor of containers location in recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, cgroupDocker, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
+		// When runs inside of a container with recent kubernetes 1.11+. Works for BestEffort and Burstable QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*.slice", "*", "docker-"+id+".scope", pidFile),
+		// Same as above but for Guaranteed QoS
+		filepath.Join(cgroupRoot, "kubepods.slice", "*", "docker-"+id+".scope", pidFile),
+	}
+
+	var filename string
+	for _, attempt := range attempts {
+		filenames, _ := filepath.Glob(attempt)
+		if len(filenames) > 1 {
+			return pid, fmt.Errorf("Ambiguous id supplied: %v", filenames)
+		} else if len(filenames) == 1 {
+			filename = filenames[0]
+			break
+		}
+	}
+
+	if filename == "" {
+		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
+	}
+
+	output, err := os.ReadFile(filename)
+	if err != nil {
+		return pid, err
+	}
+
+	result := strings.Split(string(output), "\n")
+	if len(result) == 0 || len(result[0]) == 0 {
+		return pid, fmt.Errorf("No pid found for container")
+	}
+
+	pid, err = strconv.Atoi(result[0])
+	if err != nil {
+		return pid, fmt.Errorf("Invalid pid '%s': %s", result[0], err)
+	}
+
+	return pid, nil
+}

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/netns_others.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/netns_others.go
@@ -1,0 +1,60 @@
+//go:build !linux
+// +build !linux
+
+package netns
+
+import (
+	"errors"
+)
+
+var (
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+// Setns sets namespace using golang.org/x/sys/unix.Setns on Linux. It
+// is not implemented on other platforms.
+//
+// Deprecated: Use golang.org/x/sys/unix.Setns instead.
+func Setns(ns NsHandle, nstype int) (err error) {
+	return ErrNotImplemented
+}
+
+func Set(ns NsHandle) (err error) {
+	return ErrNotImplemented
+}
+
+func New() (ns NsHandle, err error) {
+	return -1, ErrNotImplemented
+}
+
+func NewNamed(name string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func DeleteNamed(name string) error {
+	return ErrNotImplemented
+}
+
+func Get() (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromPath(path string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromName(name string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromPid(pid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromThread(pid, tid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromDocker(id string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/nshandle_linux.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/nshandle_linux.go
@@ -1,0 +1,73 @@
+package netns
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// NsHandle is a handle to a network namespace. It can be cast directly
+// to an int and used as a file descriptor.
+type NsHandle int
+
+// Equal determines if two network handles refer to the same network
+// namespace. This is done by comparing the device and inode that the
+// file descriptors point to.
+func (ns NsHandle) Equal(other NsHandle) bool {
+	if ns == other {
+		return true
+	}
+	var s1, s2 unix.Stat_t
+	if err := unix.Fstat(int(ns), &s1); err != nil {
+		return false
+	}
+	if err := unix.Fstat(int(other), &s2); err != nil {
+		return false
+	}
+	return (s1.Dev == s2.Dev) && (s1.Ino == s2.Ino)
+}
+
+// String shows the file descriptor number and its dev and inode.
+func (ns NsHandle) String() string {
+	if ns == -1 {
+		return "NS(none)"
+	}
+	var s unix.Stat_t
+	if err := unix.Fstat(int(ns), &s); err != nil {
+		return fmt.Sprintf("NS(%d: unknown)", ns)
+	}
+	return fmt.Sprintf("NS(%d: %d, %d)", ns, s.Dev, s.Ino)
+}
+
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle.
+func (ns NsHandle) UniqueId() string {
+	if ns == -1 {
+		return "NS(none)"
+	}
+	var s unix.Stat_t
+	if err := unix.Fstat(int(ns), &s); err != nil {
+		return "NS(unknown)"
+	}
+	return fmt.Sprintf("NS(%d:%d)", s.Dev, s.Ino)
+}
+
+// IsOpen returns true if Close() has not been called.
+func (ns NsHandle) IsOpen() bool {
+	return ns != -1
+}
+
+// Close closes the NsHandle and resets its file descriptor to -1.
+// It is not safe to use an NsHandle after Close() is called.
+func (ns *NsHandle) Close() error {
+	if err := unix.Close(int(*ns)); err != nil {
+		return err
+	}
+	*ns = -1
+	return nil
+}
+
+// None gets an empty (closed) NsHandle.
+func None() NsHandle {
+	return NsHandle(-1)
+}

--- a/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/nshandle_others.go
+++ b/src/code.cloudfoundry.org/vendor/github.com/vishvananda/netns/nshandle_others.go
@@ -1,0 +1,45 @@
+//go:build !linux
+// +build !linux
+
+package netns
+
+// NsHandle is a handle to a network namespace. It can only be used on Linux,
+// but provides stub methods on other platforms.
+type NsHandle int
+
+// Equal determines if two network handles refer to the same network
+// namespace. It is only implemented on Linux.
+func (ns NsHandle) Equal(_ NsHandle) bool {
+	return false
+}
+
+// String shows the file descriptor number and its dev and inode.
+// It is only implemented on Linux, and returns "NS(none)" on other
+// platforms.
+func (ns NsHandle) String() string {
+	return "NS(none)"
+}
+
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle. It is only implemented on Linux,
+// and returns "NS(none)" on other platforms.
+func (ns NsHandle) UniqueId() string {
+	return "NS(none)"
+}
+
+// IsOpen returns true if Close() has not been called. It is only implemented
+// on Linux and always returns false on other platforms.
+func (ns NsHandle) IsOpen() bool {
+	return false
+}
+
+// Close closes the NsHandle and resets its file descriptor to -1.
+// It is only implemented on Linux.
+func (ns *NsHandle) Close() error {
+	return nil
+}
+
+// None gets an empty (closed) NsHandle.
+func None() NsHandle {
+	return NsHandle(-1)
+}

--- a/src/code.cloudfoundry.org/vendor/modules.txt
+++ b/src/code.cloudfoundry.org/vendor/modules.txt
@@ -125,10 +125,11 @@ github.com/cloudfoundry/dropsonde/runtime_stats
 # github.com/cloudfoundry/sonde-go v0.0.0-20240807231527-361c7ad33dc7
 ## explicit; go 1.18
 github.com/cloudfoundry/sonde-go/events
-# github.com/containernetworking/cni v1.2.3 => github.com/containernetworking/cni v1.1.2
-## explicit; go 1.14
+# github.com/containernetworking/cni v1.2.3
+## explicit; go 1.21
 github.com/containernetworking/cni/libcni
 github.com/containernetworking/cni/pkg/invoke
+github.com/containernetworking/cni/pkg/ns
 github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/types/020
@@ -138,8 +139,8 @@ github.com/containernetworking/cni/pkg/types/create
 github.com/containernetworking/cni/pkg/types/internal
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containernetworking/plugins v1.5.1 => github.com/containernetworking/plugins v1.1.1
-## explicit; go 1.17
+# github.com/containernetworking/plugins v1.5.1
+## explicit; go 1.20
 github.com/containernetworking/plugins/pkg/ns
 github.com/containernetworking/plugins/pkg/testutils
 # github.com/coreos/go-iptables v0.8.0
@@ -310,6 +311,9 @@ github.com/tedsuo/ifrit/sigmon
 # github.com/tedsuo/rata v1.0.0
 ## explicit
 github.com/tedsuo/rata
+# github.com/vishvananda/netns v0.0.4
+## explicit; go 1.17
+github.com/vishvananda/netns
 # github.com/ziutek/mymysql v1.5.4
 ## explicit
 # go.step.sm/crypto v0.51.2
@@ -505,8 +509,6 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # example-apps/spammer => ../example-apps/spammer
-# github.com/containernetworking/cni => github.com/containernetworking/cni v1.1.2
-# github.com/containernetworking/plugins => github.com/containernetworking/plugins v1.1.1
 # github.com/nats-io/gnatsd => github.com/nats-io/gnatsd v1.1.1-0.20180411231007-da89364d9d43
 # github.com/nats-io/go-nats => github.com/nats-io/go-nats v1.5.1-0.20180331191609-247b2a84d8d0
 # github.com/nats-io/nats-top => github.com/nats-io/nats-top v0.3.3-0.20160824043733-1c2a6920a922


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR removes the `replace` directive for `containernetworking/cni` and `containernetworking/plugins` allowing their latest versions to be used.

Backward Compatibility
---------------
Breaking Change? **No**
