### PR TITLE
docs: optional parameter protocol in proxy endpoint

### DIFF
--- a/src/example-apps/proxy/README.md
+++ b/src/example-apps/proxy/README.md
@@ -66,7 +66,7 @@ $ curl https://proxy.mydomain.com/dig/example.com
 to the endpoint using UDP.
 
 ```bash
-$ curl https://proxy.mydomain.com/dig/example.com
+$ curl https://proxy.mydomain.com/digudp/example.com
 ["93.184.216.34"]
 ```
 
@@ -238,6 +238,14 @@ $ curl https://appa.mydomain.com/proxy/appB.apps.internal:8080
 {"ListenAddresses":["127.0.0.1","10.255.208.82"],"Port":8080}
 ```
 
+#### Optional parameter `protocol`
+The Proxy handler also accepts an optional string query parameter
+`protocol`.
+When set to `https`, it will:
+- Make the request to the destination using HTTPS.
+  When not set:
+- HTTP is used by default.
+
 ## `/stats`
 
 [Stats handler](./handlers/stats_handler.go) returns latency data for prior
@@ -266,7 +274,7 @@ $ curl https://appa.mydomain.com/stats
 timing information in the response.
 
 ```bash
-$ curl https://proxy.mydomain.com/dig/example.com
+$ curl https://proxy.mydomain.com/timed_dig/example.com
 {"lookup_time_ms":2,"ips":["93.184.216.34","\u003cnil\u003e"]}
 ```
 


### PR DESCRIPTION
This pull request adds essential documentation for the `protocol` query parameter in the `/proxy/${destination}` endpoint, which clarifies that setting the parameter to `https` will force the use of HTTPS, while HTTP remains the default if not specified. Additionally, it corrects several curl examples to ensure they use the correct URLs, improving overall accuracy and clarity in the documentation.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
