### PR TITLE
Fix service-discovery-perf test panic

### DIFF
--- a/src/code.cloudfoundry.org/test/performance-sd/nats_performance_test.go
+++ b/src/code.cloudfoundry.org/test/performance-sd/nats_performance_test.go
@@ -148,7 +148,7 @@ func closeSubscribers() {
 
 func startProfiler(exp *gmeasure.Experiment, cpuKey, memKey string, stopCpuProfiling chan struct{}, cpuValuesChannel chan float64) {
 	defer GinkgoRecover()
-	natsTopEngine := toputils.NewEngine(config.NatsURL, config.NatsMonitoringPort, 1000, 0)
+	natsTopEngine := toputils.NewEngine(config.NatsURL, config.NatsMonitoringPort, 1000, 1)
 	natsTopEngine.SetupHTTP()
 
 	go func() {


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
After bumping nats-top, MonitorStats() switched to using a ticker, which panics if the delay is 0, so bumping this to 1


Backward Compatibility
---------------
Breaking Change? no