### PR TITLE
Add ReadHeaderTimeout option on the service-discovery-controller

### DIFF
--- a/jobs/service-discovery-controller/spec
+++ b/jobs/service-discovery-controller/spec
@@ -51,6 +51,10 @@ properties:
     description: "Interval in seconds for which the route emitter is told to emit all routes. This value should be less than the staleness_threshold_seconds"
     default: 60
 
+  read_header_timeout:
+    description: "The amount of time allowed to read request headers"
+    default: 30s
+
   dnshttps.server.tls:
     description: "Server-side mutual TLS configuration for dns over http"
   dnshttps.client.ca:

--- a/jobs/service-discovery-controller/templates/config.json.erb
+++ b/jobs/service-discovery-controller/templates/config.json.erb
@@ -35,7 +35,8 @@ config = {
     'pruning_interval_seconds' => route_emitter_interval_seconds,
     'metrics_emit_seconds' => 10,
     'resume_pruning_delay_seconds' => route_emitter_interval_seconds,
-    'warm_duration_seconds' => route_emitter_interval_seconds
+    'warm_duration_seconds' => route_emitter_interval_seconds,
+    'read_header_timeout' => "#{p('read_header_timeout')}"
 }
 
 config['nats'] = {}

--- a/src/code.cloudfoundry.org/service-discovery-controller/config/config.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/config/config.go
@@ -7,26 +7,50 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 
 	"gopkg.in/validator.v2"
 )
 
+type DurationFlag time.Duration
+
+func (f DurationFlag) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(f).String())
+}
+
+func (f *DurationFlag) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	parsedDuration, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	*f = DurationFlag(parsedDuration)
+
+	return nil
+}
+
 type Config struct {
-	Address                   string     `json:"address" validate:"nonzero"`
-	Port                      string     `json:"port" validate:"nonzero"`
-	Nats                      NatsConfig `json:"nats"`
-	Index                     string     `json:"index"`
-	ServerCert                string     `json:"server_cert" validate:"nonzero"`
-	ServerKey                 string     `json:"server_key" validate:"nonzero"`
-	CACert                    string     `json:"ca_cert" validate:"nonzero"`
-	MetronPort                int        `json:"metron_port" validate:"min=1"`
-	LogLevelAddress           string     `json:"log_level_address"`
-	LogLevelPort              int        `json:"log_level_port"`
-	StalenessThresholdSeconds int        `json:"staleness_threshold_seconds" validate:"min=1"`
-	PruningIntervalSeconds    int        `json:"pruning_interval_seconds" validate:"min=1"`
-	MetricsEmitSeconds        int        `json:"metrics_emit_seconds" validate:"min=1"`
-	ResumePruningDelaySeconds int        `json:"resume_pruning_delay_seconds" validate:"min=0"`
-	WarmDurationSeconds       int        `json:"warm_duration_seconds" validate:"min=0"`
+	Address                   string       `json:"address" validate:"nonzero"`
+	Port                      string       `json:"port" validate:"nonzero"`
+	Nats                      NatsConfig   `json:"nats"`
+	Index                     string       `json:"index"`
+	ServerCert                string       `json:"server_cert" validate:"nonzero"`
+	ServerKey                 string       `json:"server_key" validate:"nonzero"`
+	CACert                    string       `json:"ca_cert" validate:"nonzero"`
+	MetronPort                int          `json:"metron_port" validate:"min=1"`
+	LogLevelAddress           string       `json:"log_level_address"`
+	LogLevelPort              int          `json:"log_level_port"`
+	StalenessThresholdSeconds int          `json:"staleness_threshold_seconds" validate:"min=1"`
+	PruningIntervalSeconds    int          `json:"pruning_interval_seconds" validate:"min=1"`
+	MetricsEmitSeconds        int          `json:"metrics_emit_seconds" validate:"min=1"`
+	ResumePruningDelaySeconds int          `json:"resume_pruning_delay_seconds" validate:"min=0"`
+	WarmDurationSeconds       int          `json:"warm_duration_seconds" validate:"min=0"`
+	ReadHeaderTimeout         DurationFlag `json:"read_header_timeout"`
 }
 
 type NatsConfig struct {

--- a/src/code.cloudfoundry.org/service-discovery-controller/routes/server.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/routes/server.go
@@ -106,9 +106,10 @@ func (s *Server) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 
 	serverAddress := fmt.Sprintf("%s:%s", s.config.Address, s.config.Port)
 	httpServer := &http.Server{
-		Addr:      serverAddress,
-		Handler:   mux,
-		TLSConfig: tlsConfig,
+		Addr:              serverAddress,
+		Handler:           mux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: time.Duration(s.config.ReadHeaderTimeout),
 	}
 
 	exited := make(chan error)

--- a/src/code.cloudfoundry.org/test-helpers/client.go
+++ b/src/code.cloudfoundry.org/test-helpers/client.go
@@ -7,16 +7,18 @@ import (
 )
 
 func NewClient(caCertPool *x509.CertPool, cert tls.Certificate) *http.Client {
-	tlsConfig := &tls.Config{
+	tr := &http.Transport{
+		TLSClientConfig: TLSClientConfig(caCertPool, cert),
+	}
+
+	return &http.Client{Transport: tr}
+}
+
+func TLSClientConfig(caCertPool *x509.CertPool, cert tls.Certificate) *tls.Config {
+	return &tls.Config{
 		MinVersion:   tls.VersionTLS12,
 		ClientCAs:    caCertPool,
 		RootCAs:      caCertPool,
 		Certificates: []tls.Certificate{cert},
 	}
-
-	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	return &http.Client{Transport: tr}
 }

--- a/src/code.cloudfoundry.org/test-helpers/conflicting_server.go
+++ b/src/code.cloudfoundry.org/test-helpers/conflicting_server.go
@@ -3,13 +3,14 @@ package testhelpers
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/gomega"
 )
 
 func LaunchConflictingServer(port int) *http.Server {
 	address := fmt.Sprintf("127.0.0.1:%d", port)
-	conflictingServer := &http.Server{Addr: address}
+	conflictingServer := &http.Server{Addr: address, ReadHeaderTimeout: 5 * time.Second}
 	go func() { conflictingServer.ListenAndServe() }()
 	client := &http.Client{}
 	Eventually(func() bool {


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add ReadHeaderTimeout option on service-discovery-controller server and on test server to satisfy goes G112 notice for slowloris vulnerability.


Backward Compatibility
---------------
Breaking Change? **No**
