### PR TITLE
Don't import net/http/pprof since we don't actually use it

### DIFF
--- a/src/code.cloudfoundry.org/service-discovery-controller/routes/server.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/routes/server.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"path"
 	"time"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We don't make use of net/http/pprof in this library. We import it, and it's added to to the default http server handler, but we create our own and override that, so it never gets used. 


Backward Compatibility
---------------
Breaking Change? no