### PR TITLE
Pass ReadHeaderTimeout to lagerlevel Server

### DIFF
--- a/src/code.cloudfoundry.org/bosh-dns-adapter/config/config.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/config/config.go
@@ -5,23 +5,25 @@ import (
 	"fmt"
 	"net"
 
+	"code.cloudfoundry.org/cf-networking-helpers/flags"
 	"gopkg.in/validator.v2"
 )
 
 type Config struct {
-	Address                           string   `json:"address" validate:"nonzero"`
-	Port                              string   `json:"port" validate:"nonzero"`
-	ServiceDiscoveryControllerAddress string   `json:"service_discovery_controller_address" validate:"nonzero"`
-	ServiceDiscoveryControllerPort    string   `json:"service_discovery_controller_port" validate:"nonzero"`
-	ClientCert                        string   `json:"client_cert" validate:"nonzero"`
-	ClientKey                         string   `json:"client_key" validate:"nonzero"`
-	CACert                            string   `json:"ca_cert" validate:"nonzero"`
-	MetronPort                        int      `json:"metron_port" validate:"min=1"`
-	MetricsEmitSeconds                int      `json:"metrics_emit_seconds" validate:"min=1"`
-	LogLevelAddress                   string   `json:"log_level_address" validate:"nonzero"`
-	LogLevelPort                      int      `json:"log_level_port" validate:"min=1"`
-	InternalServiceMeshDomains        []string `json:"internal_service_mesh_domains"`
-	InternalRouteVIPRange             string   `json:"internal_route_vip_range" validate:"cidr"`
+	Address                           string             `json:"address" validate:"nonzero"`
+	Port                              string             `json:"port" validate:"nonzero"`
+	ReadHeaderTimeout                 flags.DurationFlag `json:"read_header_timeout"`
+	ServiceDiscoveryControllerAddress string             `json:"service_discovery_controller_address" validate:"nonzero"`
+	ServiceDiscoveryControllerPort    string             `json:"service_discovery_controller_port" validate:"nonzero"`
+	ClientCert                        string             `json:"client_cert" validate:"nonzero"`
+	ClientKey                         string             `json:"client_key" validate:"nonzero"`
+	CACert                            string             `json:"ca_cert" validate:"nonzero"`
+	MetronPort                        int                `json:"metron_port" validate:"min=1"`
+	MetricsEmitSeconds                int                `json:"metrics_emit_seconds" validate:"min=1"`
+	LogLevelAddress                   string             `json:"log_level_address" validate:"nonzero"`
+	LogLevelPort                      int                `json:"log_level_port" validate:"min=1"`
+	InternalServiceMeshDomains        []string           `json:"internal_service_mesh_domains"`
+	InternalRouteVIPRange             string             `json:"internal_route_vip_range" validate:"cidr"`
 }
 
 func init() {

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/main.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/main.go
@@ -106,7 +106,7 @@ func main() {
 
 	members := grouper.Members{
 		{Name: "metrics-emitter", Runner: metricsEmitter},
-		{Name: "log-level-server", Runner: lagerlevel.NewServer(config.LogLevelAddress, config.LogLevelPort, reconfigurableSink, logger.Session("log-level-server"))},
+		{Name: "log-level-server", Runner: lagerlevel.NewServer(config.LogLevelAddress, config.LogLevelPort, time.Duration(config.ReadHeaderTimeout), reconfigurableSink, logger.Session("log-level-server"))},
 	}
 	group := grouper.NewOrdered(os.Interrupt, members)
 	monitor := ifrit.Invoke(sigmon.New(group))

--- a/src/code.cloudfoundry.org/service-discovery-controller/config/config.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/config/config.go
@@ -7,50 +7,28 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
-	"time"
 
+	"code.cloudfoundry.org/cf-networking-helpers/flags"
 	"gopkg.in/validator.v2"
 )
 
-type DurationFlag time.Duration
-
-func (f DurationFlag) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Duration(f).String())
-}
-
-func (f *DurationFlag) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	parsedDuration, err := time.ParseDuration(s)
-	if err != nil {
-		return err
-	}
-
-	*f = DurationFlag(parsedDuration)
-
-	return nil
-}
-
 type Config struct {
-	Address                   string       `json:"address" validate:"nonzero"`
-	Port                      string       `json:"port" validate:"nonzero"`
-	Nats                      NatsConfig   `json:"nats"`
-	Index                     string       `json:"index"`
-	ServerCert                string       `json:"server_cert" validate:"nonzero"`
-	ServerKey                 string       `json:"server_key" validate:"nonzero"`
-	CACert                    string       `json:"ca_cert" validate:"nonzero"`
-	MetronPort                int          `json:"metron_port" validate:"min=1"`
-	LogLevelAddress           string       `json:"log_level_address"`
-	LogLevelPort              int          `json:"log_level_port"`
-	StalenessThresholdSeconds int          `json:"staleness_threshold_seconds" validate:"min=1"`
-	PruningIntervalSeconds    int          `json:"pruning_interval_seconds" validate:"min=1"`
-	MetricsEmitSeconds        int          `json:"metrics_emit_seconds" validate:"min=1"`
-	ResumePruningDelaySeconds int          `json:"resume_pruning_delay_seconds" validate:"min=0"`
-	WarmDurationSeconds       int          `json:"warm_duration_seconds" validate:"min=0"`
-	ReadHeaderTimeout         DurationFlag `json:"read_header_timeout"`
+	Address                   string             `json:"address" validate:"nonzero"`
+	Port                      string             `json:"port" validate:"nonzero"`
+	Nats                      NatsConfig         `json:"nats"`
+	Index                     string             `json:"index"`
+	ServerCert                string             `json:"server_cert" validate:"nonzero"`
+	ServerKey                 string             `json:"server_key" validate:"nonzero"`
+	CACert                    string             `json:"ca_cert" validate:"nonzero"`
+	MetronPort                int                `json:"metron_port" validate:"min=1"`
+	LogLevelAddress           string             `json:"log_level_address"`
+	LogLevelPort              int                `json:"log_level_port"`
+	StalenessThresholdSeconds int                `json:"staleness_threshold_seconds" validate:"min=1"`
+	PruningIntervalSeconds    int                `json:"pruning_interval_seconds" validate:"min=1"`
+	MetricsEmitSeconds        int                `json:"metrics_emit_seconds" validate:"min=1"`
+	ResumePruningDelaySeconds int                `json:"resume_pruning_delay_seconds" validate:"min=0"`
+	WarmDurationSeconds       int                `json:"warm_duration_seconds" validate:"min=0"`
+	ReadHeaderTimeout         flags.DurationFlag `json:"read_header_timeout"`
 }
 
 type NatsConfig struct {

--- a/src/code.cloudfoundry.org/service-discovery-controller/config/config_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"code.cloudfoundry.org/cf-networking-helpers/flags"
 	. "code.cloudfoundry.org/service-discovery-controller/config"
 	testhelpers "code.cloudfoundry.org/test-helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -68,7 +69,7 @@ var _ = Describe("Config", func() {
 			Expect(parsedConfig.MetricsEmitSeconds).To(Equal(6))
 			Expect(parsedConfig.ResumePruningDelaySeconds).To(Equal(2))
 			Expect(parsedConfig.WarmDurationSeconds).To(Equal(5))
-			Expect(parsedConfig.ReadHeaderTimeout).To(Equal(DurationFlag(10 * time.Second)))
+			Expect(parsedConfig.ReadHeaderTimeout).To(Equal(flags.DurationFlag(10 * time.Second)))
 		})
 	})
 
@@ -192,7 +193,7 @@ var _ = Describe("Config", func() {
 			config, err := NewConfig(cfgBytes)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.ReadHeaderTimeout).To(Equal(DurationFlag(0)))
+			Expect(config.ReadHeaderTimeout).To(Equal(flags.DurationFlag(0)))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/service-discovery-controller/main.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/main.go
@@ -100,6 +100,7 @@ func mainWithError() error {
 	logLevelServer := lagerlevel.NewServer(
 		conf.LogLevelAddress,
 		conf.LogLevelPort,
+		time.Duration(conf.ReadHeaderTimeout),
 		sink,
 		logger.Session("log-level-server"),
 	)

--- a/src/code.cloudfoundry.org/service-discovery-controller/routes/server_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/routes/server_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"code.cloudfoundry.org/cf-networking-helpers/flags"
 	"code.cloudfoundry.org/cf-networking-helpers/testsupport/ports"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
@@ -52,7 +53,7 @@ var _ = Describe("Server", func() {
 			CACert:            caFile,
 			ServerCert:        serverCert,
 			ServerKey:         serverKey,
-			ReadHeaderTimeout: config.DurationFlag(200 * time.Millisecond),
+			ReadHeaderTimeout: flags.DurationFlag(200 * time.Millisecond),
 		}
 		addressTable = &fakes.AddressTable{}
 		dnsRequestRecorder = &fakes.DNSRequestRecorder{}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Service-discovery-controller and bosh-dns-adapter need to pass ReadHeaderTimeout argument when instantiating new lagerlelvel Server.

DurationFlag type definition is now moved to cf-networking-helpers since it is used by bosh-dns-adapter as well.

This PR requires the following change to lagerlevel and vendored it in - https://github.com/cloudfoundry/cf-networking-helpers/pull/101


Backward Compatibility
---------------
Breaking Change? **No**

laverlevel should not be used externally.
