### PR TITLE
Bump the example-apps to Golang 1.23

### DIFF
--- a/src/example-apps/proxy/manifest.yml
+++ b/src/example-apps/proxy/manifest.yml
@@ -6,4 +6,4 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: proxy
-      GOVERSION: go1.21
+      GOVERSION: go1.23

--- a/src/example-apps/raw-response/manifest.yml
+++ b/src/example-apps/raw-response/manifest.yml
@@ -6,4 +6,4 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: raw-response
-      GOVERSION: go1.21
+      GOVERSION: go1.23

--- a/src/example-apps/registry/manifest.yml
+++ b/src/example-apps/registry/manifest.yml
@@ -7,4 +7,4 @@ applications:
     instances: 1
     env:
       GOPACKAGENAME: registry
-      GOVERSION: go1.21
+      GOVERSION: go1.23

--- a/src/example-apps/smoke/manifest.yml
+++ b/src/example-apps/smoke/manifest.yml
@@ -6,5 +6,5 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: smoke
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       PROXY_APP_URL: http://proxy.some-cf-deployment.example.com

--- a/src/example-apps/spammer/manifest.yml
+++ b/src/example-apps/spammer/manifest.yml
@@ -6,4 +6,4 @@ applications:
   buildpacks: [go_buildpack]
   env:
     GOPACKAGENAME: example-apps/spammer
-    GOVERSION: go1.21
+    GOVERSION: go1.23

--- a/src/example-apps/tick/manifest.yml
+++ b/src/example-apps/tick/manifest.yml
@@ -7,7 +7,7 @@ applications:
     instances: 3
     env:
       GOPACKAGENAME: tick
-      GOVERSION: go1.21
+      GOVERSION: go1.23
       REGISTRY_BASE_URL: http://registry.some-cf-deployment.example.com
       START_PORT: 7000
       LISTEN_PORTS: 3


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

This PR bumps the example apps to Golang 1.23 as Golang 1.21 is no longer supported.

The latest go-buildpack ([v1.10.23](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.10.23)) removes support for Golang 1.21, so the apps will no longer stage, which breaks using them to run the acceptance tests.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
