### PR TITLE
Use Server struct to address gosec G114

### DIFF
--- a/src/example-apps/proxy/main.go
+++ b/src/example-apps/proxy/main.go
@@ -40,7 +40,11 @@ func main() {
 	mux.Handle("/signal/", &handlers.SignalHandler{})
 	mux.Handle("/sleepy/", &handlers.SleepyHandler{SleepyInterval: sleepyInterval})
 
-	err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), mux)
+	server := &http.Server{
+		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+		Handler: mux,
+	}
+	err := server.ListenAndServe()
 	log.Printf("http server exited: %s", err)
 }
 

--- a/src/example-apps/smoke/main.go
+++ b/src/example-apps/smoke/main.go
@@ -35,7 +35,11 @@ func launchServer(port int) {
 	mux := http.NewServeMux()
 	mux.Handle("/selfproxy", selfProxyHandler)
 	mux.Handle("/", helloHandler)
-	err := http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), mux)
+	server := &http.Server{
+		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+		Handler: mux,
+	}
+	err := server.ListenAndServe()
 	log.Printf("http server exited: %s\n", err)
 }
 

--- a/src/example-apps/spammer/main.go
+++ b/src/example-apps/spammer/main.go
@@ -10,7 +10,10 @@ import (
 func main() {
 	http.HandleFunc(api.SpamPath, api.SpamHandler)
 
-	if err := http.ListenAndServe(":8080", nil); err != nil {
-		log.Fatalf("An error occured during serving: %s", err)
+	server := &http.Server{
+		Addr:    ":8080",
+		Handler: nil,
 	}
+	err := server.ListenAndServe()
+	log.Fatalf("An error occured during serving: %s", err)
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Use `Server` struct, which allow specifying a timeout, to address gosec G114


Backward Compatibility
---------------
Breaking Change? **No**
