### PR TITLE
add new proxy handler: extra response headers

### DIFF
--- a/src/example-apps/proxy/README.md
+++ b/src/example-apps/proxy/README.md
@@ -195,6 +195,37 @@ with a 200 status code. You can configure how many times the endpoint should
 fail before succeeding by setting the `EVENTUALLY_SUCCEED_AFTER_COUNT` env var.
 This endpoint was created to test app healthchecks.
 
+## `/extraresponseheaders/${extra_number_of_response_headers}`
+
+[Extra Response Headers handler](./handlers/extra_response_headers.go) adds the desired
+number of extra headers to your response.
+
+```bash
+$ curl https://proxy.mydomain.com/extraresponseheaders/10 -v
+
+> GET /extraresponseheaders/10 HTTP/1.1
+> Host: proxy.mydomain.com
+> User-Agent: curl/7.81.0
+> Accept: */*
+>
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< Content-Length: 0
+< Date: Fri, 15 Nov 2024 21:24:05 GMT
+< Meow-0: meow-0
+< Meow-1: meow-1
+< Meow-2: meow-2
+< Meow-3: meow-3
+< Meow-4: meow-4
+< Meow-5: meow-5
+< Meow-6: meow-6
+< Meow-7: meow-7
+< Meow-8: meow-8
+< Meow-9: meow-9
+< X-Vcap-Request-Id: 1fc41493-5fd1-4477-4582-d7ff1b715df2
+<
+```
+
 ## `/flap`
 
 [Flap handler](./handlers/flap_handler.go) responds to the first 5 requests

--- a/src/example-apps/proxy/handlers/extra_response_headers.go
+++ b/src/example-apps/proxy/handlers/extra_response_headers.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type ExtraResponseHeadersHandler struct {
+}
+
+func (h *ExtraResponseHeadersHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	logger := log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime)
+	extraHeaders := strings.TrimPrefix(req.URL.Path, "/extraresponseheaders/")
+	extraHeaders = strings.TrimSuffix(extraHeaders, "/")
+	numExtraHeaders, err := strconv.Atoi(extraHeaders)
+
+	if err != nil {
+		logger.Println("You must pass an int in the URL. For example: 'URL/extraheaders/10'.")
+		resp.WriteHeader(http.StatusBadRequest)
+	}
+
+	var header string
+	for i := 0; i < numExtraHeaders; i++ {
+		header = fmt.Sprintf("meow-%d", i)
+		resp.Header().Set(header, header)
+	}
+}

--- a/src/example-apps/proxy/handlers/extra_response_headers_test.go
+++ b/src/example-apps/proxy/handlers/extra_response_headers_test.go
@@ -1,0 +1,58 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"proxy/handlers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExtraResponseHeadersHandler", func() {
+	var (
+		h      *handlers.ExtraResponseHeadersHandler
+		ts     *httptest.Server
+		client *http.Client
+	)
+
+	BeforeEach(func() {
+		h = &handlers.ExtraResponseHeadersHandler{}
+		ts = httptest.NewServer(h)
+		client = &http.Client{}
+	})
+
+	Context("when a number is passed", func() {
+		It("adds extra headers", func() {
+
+			By("first getting the default number of headers")
+			resp, err := client.Get(ts.URL + "/extraresponseheaders/0")
+			Expect(err).NotTo(HaveOccurred())
+			defaultNumberOfHeaders := len(resp.Header)
+			Expect(defaultNumberOfHeaders).To(BeNumerically(">", 1))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			By("checking that the number of headers increased by the correct amount")
+			extraHeadersToAdd := 10
+			resp, err = client.Get(ts.URL + fmt.Sprintf("/extraresponseheaders/%d", extraHeadersToAdd))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(resp.Header)).To(Equal(defaultNumberOfHeaders + extraHeadersToAdd))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			By("checking that it works even with a trailing slash")
+			resp, err = client.Get(ts.URL + fmt.Sprintf("/extraresponseheaders/%d/", extraHeadersToAdd))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(resp.Header)).To(Equal(defaultNumberOfHeaders + extraHeadersToAdd))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+
+	Context("when a number is not passed", func() {
+		It("returns a status code 400 and logs an error", func() {
+			resp, err := client.Get(ts.URL + "/extraresponseheaders/meow/")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+})

--- a/src/example-apps/proxy/main.go
+++ b/src/example-apps/proxy/main.go
@@ -40,6 +40,7 @@ func main() {
 	mux.Handle("/flap", &handlers.FlapHandler{FlapInterval: flapInterval})
 	mux.Handle("/signal/", &handlers.SignalHandler{})
 	mux.Handle("/sleepy/", &handlers.SleepyHandler{SleepyInterval: sleepyInterval})
+	mux.Handle("/extraresponseheaders/", &handlers.ExtraResponseHeadersHandler{})
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf("0.0.0.0:%d", port),


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
See readme in changes. This is helpful for testing response headers, like in this issue: https://github.com/cloudfoundry/routing-release/issues/309


Backward Compatibility
---------------
Breaking Change? No
