### PR TITLE
Bump rspec -> 3.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     benchmark (0.2.1)
     bosh-template (2.4.0)
       semi_semantic (~> 1.2.0)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     e2mmap (0.1.0)
     jaro_winkler (1.5.6)
     json (2.6.3)
@@ -31,19 +31,19 @@ GEM
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.3.9)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
     rubocop (1.57.1)
       base64 (~> 0.1.1)
       json (~> 2.3)
@@ -91,4 +91,4 @@ DEPENDENCIES
   solargraph
 
 BUNDLED WITH
-   2.4.19
+   2.5.23


### PR DESCRIPTION
- [V] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
The current versions for rspec is older than a year.
Bumping rspec -> 3.13.0 to fit the SAP requirements for OSS compliance.

The tests have been executed locally by executing 'scripts/test-in-docker.bash'. The tests' output did not change after bumping the versions.

Executed commands:
bundle update rspec
