### PR TITLE
Remove v2 endpoints

### DIFF
--- a/src/code.cloudfoundry.org/cf-pusher/cf_cli_adapter/adapter.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_cli_adapter/adapter.go
@@ -158,7 +158,9 @@ func (a *Adapter) SpaceGuid(name string) (string, error) {
 }
 
 type Apps struct {
-	TotalResults int `json:"total_results"`
+	Pagination struct {
+		TotalResults int `json:"total_results"`
+	} `json:"pagination"`
 }
 
 func (a *Adapter) OrgGuid(name string) (string, error) {
@@ -185,7 +187,7 @@ func (a *Adapter) Curl(method, path, inputFile string) ([]byte, error) {
 }
 
 func (a *Adapter) AppCount(orgGuid string) (int, error) {
-	commandArgs := []string{"curl", fmt.Sprintf("/v2/apps?q=organization_guid%%20IN%%20%s", orgGuid)}
+	commandArgs := []string{"curl", fmt.Sprintf("/v3/apps?organization_guids=%s", orgGuid)}
 	a.LogCommand(commandArgs)
 	cmd := exec.Command(a.cfCliPath, commandArgs...)
 	bytes, err := a.runCombinedOutput(cmd)
@@ -193,11 +195,11 @@ func (a *Adapter) AppCount(orgGuid string) (int, error) {
 	if err := json.Unmarshal(bytes, apps); err != nil {
 		return -1, err
 	}
-	return apps.TotalResults, err
+	return apps.Pagination.TotalResults, err
 }
 
 func (a *Adapter) CheckApp(guid string) ([]byte, error) {
-	commandArgs := []string{"curl", fmt.Sprintf("/v2/apps/%s/summary", guid)}
+	commandArgs := []string{"curl", fmt.Sprintf("/v3/apps/%s/processes/web/stats", guid)}
 	a.LogCommand(commandArgs)
 	cmd := exec.Command(a.cfCliPath, commandArgs...)
 	return a.runCombinedOutput(cmd)

--- a/src/code.cloudfoundry.org/cf-pusher/cf_command/app_checker.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_command/app_checker.go
@@ -21,11 +21,25 @@ type AppChecker struct {
 }
 
 type AppStatus struct {
-	GUID             string `json:"guid"`
-	Name             string `json:"name"`
-	RunningInstances int    `json:"running_instances"`
-	Instances        int    `json:"instances"`
-	State            string `json:"state"`
+	Resources []AppResource `json:"resources"`
+}
+
+type AppResource struct {
+	State string `json:"state"`
+}
+
+func (a AppStatus) Running() int {
+	count := 0
+	for _, value := range a.Resources {
+		if value.State == "RUNNING" {
+			count++
+		}
+	}
+	return count
+
+}
+func (a AppStatus) Total() int {
+	return len(a.Resources)
 }
 
 func (a *AppChecker) CheckApps(appSpec map[string]int) error {
@@ -66,19 +80,19 @@ func (a *AppChecker) CheckApps(appSpec map[string]int) error {
 				return
 			}
 
-			if s.Instances == 0 {
+			if s.Total() == 0 {
 				errs <- fmt.Errorf("checking app %s: %s", app.Name, "no instances are running")
 				return
 			}
 
-			if s.RunningInstances != s.Instances {
+			if s.Running() != s.Total() {
 				errs <- fmt.Errorf("checking app %s: %s", app.Name, "not all instances are running")
 				return
 			}
 
 			if desiredInstances, ok := appSpec[app.Name]; ok {
-				if appSpec[app.Name] != s.RunningInstances {
-					errs <- fmt.Errorf("checking app %s: %s, running: %d desired: %d", app.Name, "not running desired instances", s.RunningInstances, desiredInstances)
+				if appSpec[app.Name] != s.Running() {
+					errs <- fmt.Errorf("checking app %s: %s, running: %d desired: %d", app.Name, "not running desired instances", s.Running(), desiredInstances)
 					return
 				}
 			} else {

--- a/src/code.cloudfoundry.org/cf-pusher/cf_command/app_checker_test.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_command/app_checker_test.go
@@ -38,6 +38,7 @@ var _ = Describe("AppChecker", func() {
 			fakeAdapter.CheckAppReturns([]byte(str), nil)
 			fakeAdapter.OrgGuidReturns("some-org-guid", nil)
 			fakeAdapter.AppCountReturns(1, nil)
+			fakeAdapter.CheckAppReturns([]byte(`{"resources":[{"state":"RUNNING"},{"state":"RUNNING"}]}`), nil)
 		})
 		It("when the app is in state running", func() {
 			err := appChecker.CheckApps(appSpec)
@@ -58,6 +59,7 @@ var _ = Describe("AppChecker", func() {
 		Context("when an app is not running the specified number of instances", func() {
 			BeforeEach(func() {
 				appSpec["some-name-1"] = 1
+				fakeAdapter.CheckAppReturns([]byte(`{"resources":[{"state":"RUNNING"},{"state":"RUNNING"}]}`), nil)
 			})
 			It("returns an error", func() {
 				err := appChecker.CheckApps(appSpec)
@@ -71,6 +73,7 @@ var _ = Describe("AppChecker", func() {
 					Name: "banana",
 				})
 				fakeAdapter.AppCountReturns(2, nil)
+				fakeAdapter.CheckAppReturns([]byte(`{"resources":[{"state":"RUNNING"},{"state":"RUNNING"}]}`), nil)
 			})
 			It("returns a helpful error", func() {
 				err := appChecker.CheckApps(appSpec)
@@ -166,8 +169,7 @@ var _ = Describe("AppChecker", func() {
 
 		Context("when one app is not running", func() {
 			BeforeEach(func() {
-				str := `{ "guid": "some-guid-1", "name": "scale-tick-1", "running_instances": 1, "instances": 2, "state": "STARTED"}`
-				fakeAdapter.CheckAppReturns([]byte(str), nil)
+				fakeAdapter.CheckAppReturns([]byte(`{"resources":[{"state":"STARTED"}]}`), nil)
 			})
 			It("returns a meaningul error", func() {
 				err := appChecker.CheckApps(appSpec)

--- a/src/code.cloudfoundry.org/cf-pusher/cf_command/app_pusher.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_command/app_pusher.go
@@ -46,7 +46,7 @@ func (a *AppPusher) shouldPushApp(name string) bool {
 
 		s := &AppStatus{}
 		err = json.Unmarshal(appBytes, s)
-		if err != nil || s.RunningInstances < a.DesiredRunningInstances {
+		if err != nil || s.Running() < a.DesiredRunningInstances {
 			// Error unmarshalling response
 			return true
 		}

--- a/src/code.cloudfoundry.org/cf-pusher/cf_command/app_pusher_test.go
+++ b/src/code.cloudfoundry.org/cf-pusher/cf_command/app_pusher_test.go
@@ -158,7 +158,8 @@ var _ = Describe("AppPusher", func() {
 
 				fakeAdapter.CheckAppStub = func(guid string) ([]byte, error) {
 					if guid == "app-to-be-skipped-guid" {
-						return []byte(`{"running_instances": 5}`), nil
+						fakeAdapter.CheckAppReturns([]byte(`{"resources":[{"state":"STARTED"}]}`), nil)
+						return []byte(`{"resources":[{"state":"RUNNING"},{"state":"RUNNING"},{"state":"RUNNING"},{"state":"RUNNING"},{"state":"RUNNING"}]}`), nil
 					} else if guid == "not-enough-instances-guid" {
 						return []byte(`{"running_instances": 3}`), nil
 					} else if guid == "failed-unmarshalling-app-guid" {

--- a/src/code.cloudfoundry.org/policy-server/cc_client/client.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/client.go
@@ -20,9 +20,8 @@ const SECURITY_GROUPS_PER_PAGE = 5000
 //counterfeiter:generate -o fakes/cc_client.go --fake-name CCClient . CCClient
 type CCClient interface {
 	GetAppSpaces(token string, appGUIDs []string) (map[string]string, error)
-	GetSpace(token, spaceGUID string) (*SpaceResponse, error)
 	GetSpaceGUIDs(token string, appGUIDs []string) ([]string, error)
-	GetSubjectSpace(token, subjectId string, spaces SpaceResponse) (*SpaceResource, error)
+	GetSubjectSpace(token, subjectId, spaceGUID string) (*RolesV3Resource, error)
 	GetSubjectSpaces(token, subjectId string) (map[string]struct{}, error)
 	GetLiveAppGUIDs(token string, appGUIDs []string) (map[string]struct{}, error)
 	GetLiveSpaceGUIDs(token string, spaceGUIDs []string) (map[string]struct{}, error)
@@ -109,6 +108,35 @@ type AppsV3Response struct {
 	} `json:"resources"`
 }
 
+type RolesV3Response struct {
+	Pagination struct {
+		TotalPages  int `json:"total_pages"`
+		TotalResult int `json:"total_result"`
+		First       struct {
+			Href string `json:"href"`
+		} `json:"first"`
+		Last struct {
+			Href string `json:"href"`
+		} `json:"last"`
+		Next struct {
+			Href string `json:"href"`
+		} `json:"next"`
+	} `json:"pagination"`
+	Resources []RolesV3Resource `json:"resources"`
+}
+
+type RolesV3Resource struct {
+	Relationships RoleRelationship `json:"relationships"`
+}
+
+type RoleRelationship struct {
+	Space struct {
+		Data struct {
+			GUID string `json:"guid"`
+		} `json:"data"`
+	} `json:"space"`
+}
+
 type SpacesV3Response struct {
 	Pagination struct {
 		TotalPages int `json:"total_pages"`
@@ -122,33 +150,20 @@ type SpacesV3Response struct {
 			Href string `json:"href"`
 		} `json:"next"`
 	} `json:"pagination"`
-	Resources []struct {
-		GUID string `json:"guid"`
-	} `json:"resources"`
+	Resources []SpacesV3Resource `json:"resources"`
 }
 
-type SpaceResponse struct {
-	Entity SpaceEntity `json:"entity"`
+type SpacesV3Resource struct {
+	GUID          string             `json:"guid"`
+	Name          string             `json:"name"`
+	Relationships SpaceRelationships `json:"relationships"`
 }
-
-type SpaceEntity struct {
-	Name             string `json:"name"`
-	OrganizationGUID string `json:"organization_guid"`
-}
-
-type SpaceResource struct {
-	Metadata struct {
-		GUID string `json:"guid"`
-	}
-	Entity SpaceEntity `json:"entity"`
-}
-
-type SpacesResponse struct {
-	TotalResults int64           `json:"total_results"`
-	TotalPages   int64           `json:"total_pages"`
-	PrevUrl      string          `json:"prev_url"`
-	NextUrl      string          `json:"next_url"`
-	Resources    []SpaceResource `json:"resources"`
+type SpaceRelationships struct {
+	Organization struct {
+		Data struct {
+			GUID string `json:"guid"`
+		} `json:"data"`
+	} `json:"organization"`
 }
 
 func (c *Client) GetAllAppGUIDs(token string) (map[string]struct{}, error) {
@@ -316,13 +331,13 @@ func (c *Client) GetAppSpaces(token string, appGUIDs []string) (map[string]strin
 	return set, nil
 }
 
-func (c *Client) GetSpace(token, spaceGUID string) (*SpaceResponse, error) {
+func (c *Client) GetSpace(token, spaceGUID string) (*SpacesV3Response, error) {
 	c.Logger.Info("get-space", lager.Data{"space-guid": spaceGUID})
 	token = fmt.Sprintf("bearer %s", token)
-	route := fmt.Sprintf("/v2/spaces/%s", spaceGUID)
+	route := fmt.Sprintf("/v3/spaces?guids=%s", spaceGUID)
 	c.Logger.Debug("get-space-request", lager.Data{"route": route})
 
-	var response SpaceResponse
+	var response SpacesV3Response
 	err := c.ExternalJSONClient.Do("GET", route, nil, &response, token)
 	if err != nil {
 		typedErr, ok := err.(*json_client.HttpResponseCodeError)
@@ -335,25 +350,26 @@ func (c *Client) GetSpace(token, spaceGUID string) (*SpaceResponse, error) {
 		}
 		return nil, fmt.Errorf("json client do: %s", err)
 	}
-	c.Logger.Debug("get-space-response", lager.Data{"resources": response.Entity})
+	c.Logger.Debug("get-space-response", lager.Data{"resources": response.Resources})
 
 	return &response, nil
 }
 
-func (c *Client) GetSubjectSpace(token, subjectId string, space SpaceResponse) (*SpaceResource, error) {
-	c.Logger.Info("get-subject-space", lager.Data{"subject-id": subjectId, "space-response": space})
+func (c *Client) GetSubjectSpace(token, subjectId, spaceGUID string) (*RolesV3Resource, error) {
+	c.Logger.Info("get-subject-space", lager.Data{"subject-id": subjectId, "space-guid": spaceGUID})
 	token = fmt.Sprintf("bearer %s", token)
 
 	values := url.Values{}
-	values.Add("q", fmt.Sprintf("developer_guid:%s", subjectId))
-	values.Add("q", fmt.Sprintf("name:%s", space.Entity.Name))
-	values.Add("q", fmt.Sprintf("organization_guid:%s", space.Entity.OrganizationGUID))
+	values.Add("types", "space_developer")
+	values.Add("user_guids", subjectId)
+	values.Add("space_guids", spaceGUID)
+	values.Add("include", "space")
 
-	route := fmt.Sprintf("/v2/spaces?%s", values.Encode())
+	route := fmt.Sprintf("/v3/roles?%s", values.Encode())
 
 	c.Logger.Debug("get-subject-space-request", lager.Data{"route": route})
 
-	var response SpacesResponse
+	var response RolesV3Response
 	err := c.ExternalJSONClient.Do("GET", route, nil, &response, token)
 	if err != nil {
 		return nil, fmt.Errorf("json client do: %s", err)
@@ -379,29 +395,31 @@ func (c *Client) GetSubjectSpaces(token, subjectId string) (map[string]struct{},
 	token = fmt.Sprintf("bearer %s", token)
 
 	values := url.Values{}
-	values.Add("results-per-page", maximumPageSize)
+	values.Add("per_page", maximumPageSize)
+	values.Add("user_guids", subjectId)
+	values.Add("include", "space")
 
-	route := fmt.Sprintf("/v2/users/%s/spaces?%s", subjectId, values.Encode())
+	route := fmt.Sprintf("/v3/roles?%s", values.Encode())
 
 	c.Logger.Debug("get-subject-spaces-request", lager.Data{"route": route})
 
-	var resources []SpaceResource
+	var resources []RolesV3Resource
 	for route != "" {
-		var response SpacesResponse
+		var response RolesV3Response
 		err := c.ExternalJSONClient.Do("GET", route, nil, &response, token)
 		if err != nil {
 			return nil, fmt.Errorf("json client do: %s", err)
 		}
 
-		c.Logger.Debug("get-subject-spaces-response", lager.Data{"resources": response.Resources, "next-url": response.NextUrl})
+		c.Logger.Debug("get-subject-spaces-response", lager.Data{"resources": response.Resources, "next-url": response.Pagination.Next.Href})
 
-		route = response.NextUrl
+		route = response.Pagination.Next.Href
 		resources = append(resources, response.Resources...)
 	}
 
 	subjectSpaces := map[string]struct{}{}
 	for _, space := range resources {
-		spaceID := space.Metadata.GUID
+		spaceID := space.Relationships.Space.Data.GUID
 		subjectSpaces[spaceID] = struct{}{}
 	}
 

--- a/src/code.cloudfoundry.org/policy-server/cc_client/client_test.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/client_test.go
@@ -296,12 +296,11 @@ var _ = Describe("Client", func() {
 		})
 
 		It("returns the space with the matching GUID", func() {
-			space := cc_client.SpaceResponse{
-				Entity: cc_client.SpaceEntity{
-					Name:             "name-2064",
-					OrganizationGUID: "6e1ca5aa-55f1-4110-a97f-1f3473e771b9",
-				},
-			}
+			space := new(cc_client.SpacesV3Response)
+			space.Resources = make([]cc_client.SpacesV3Resource, 1)
+			space.Resources[0].Name = "some-space-name"
+			space.Resources[0].GUID = "some-space-guid"
+			space.Resources[0].Relationships.Organization.Data.GUID = "6e1ca5aa-55f1-4110-a97f-1f3473e771b9"
 
 			matchingSpace, err := client.GetSpace("some-token", "some-space-guid")
 			Expect(err).NotTo(HaveOccurred())
@@ -311,11 +310,11 @@ var _ = Describe("Client", func() {
 			method, route, reqData, _, token := fakeExternalJSONClient.DoArgsForCall(0)
 
 			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/spaces/some-space-guid"))
+			Expect(route).To(Equal("/v3/spaces?guids=some-space-guid"))
 			Expect(reqData).To(BeNil())
 			Expect(token).To(Equal("bearer some-token"))
 
-			Expect(matchingSpace).To(Equal(&space))
+			Expect(matchingSpace).To(Equal(space))
 		})
 
 		Context("when the json client returns an error", func() {
@@ -471,21 +470,21 @@ var _ = Describe("Client", func() {
 			method, route, reqData, _, token := fakeExternalJSONClient.DoArgsForCall(0)
 
 			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/users/some-subject-id/spaces?results-per-page=100"))
+			Expect(route).To(Equal("/v3/roles?include=space&per_page=100&user_guids=some-subject-id"))
 			Expect(reqData).To(BeNil())
 			Expect(token).To(Equal("bearer some-token"))
 
 			method, route, reqData, _, token = fakeExternalJSONClient.DoArgsForCall(1)
 
 			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/users/some-subject-id/spaces?order-direction=asc&page=2&results-per-page=1"))
+			Expect(route).To(Equal("https://api.example.org/v3/roles?page=2&per_page=2"))
 			Expect(reqData).To(BeNil())
 			Expect(token).To(Equal("bearer some-token"))
 
 			method, route, reqData, _, token = fakeExternalJSONClient.DoArgsForCall(2)
 
 			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/users/some-subject-id/spaces?order-direction=asc&page=3&results-per-page=1"))
+			Expect(route).To(Equal("https://api.example.org/v3/roles?page=3&per_page=2"))
 			Expect(reqData).To(BeNil())
 			Expect(token).To(Equal("bearer some-token"))
 
@@ -509,33 +508,15 @@ var _ = Describe("Client", func() {
 	})
 
 	Describe("GetSubjectSpace", func() {
-		space := cc_client.SpaceResponse{
-			Entity: cc_client.SpaceEntity{
-				Name:             "some-space-name",
-				OrganizationGUID: "some-org-guid",
-			},
-		}
+		var spaceGUID string
 		BeforeEach(func() {
+
+			spaceGUID = "some-space-name"
+
 			fakeExternalJSONClient.DoStub = func(method, route string, reqData, respData interface{}, token string) error {
 				_ = json.Unmarshal([]byte(fixtures.SubjectSpace), respData)
 				return nil
 			}
-		})
-
-		It("returns the matching spaces for the subject", func() {
-			matchingSpace, err := client.GetSubjectSpace("some-token", "some-subject-id", space)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(fakeExternalJSONClient.DoCallCount()).To(Equal(1))
-
-			method, route, reqData, _, token := fakeExternalJSONClient.DoArgsForCall(0)
-
-			Expect(method).To(Equal("GET"))
-			Expect(route).To(Equal("/v2/spaces?q=developer_guid%3Asome-subject-id&q=name%3Asome-space-name&q=organization_guid%3Asome-org-guid"))
-			Expect(reqData).To(BeNil())
-			Expect(token).To(Equal("bearer some-token"))
-
-			Expect(matchingSpace.Entity).To(Equal(space.Entity))
 		})
 
 		Context("when the subject has no spaces", func() {
@@ -547,7 +528,7 @@ var _ = Describe("Client", func() {
 			})
 
 			It("returns nil", func() {
-				space, err := client.GetSubjectSpace("some-token", "some-subject-id", space)
+				space, err := client.GetSubjectSpace("some-token", "some-subject-id", spaceGUID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(space).To(BeNil())
 			})
@@ -562,7 +543,7 @@ var _ = Describe("Client", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := client.GetSubjectSpace("some-token", "some-subject-id", space)
+				_, err := client.GetSubjectSpace("some-token", "some-subject-id", spaceGUID)
 				Expect(err).To(MatchError("found more than one matching space"))
 			})
 		})
@@ -573,7 +554,7 @@ var _ = Describe("Client", func() {
 			})
 
 			It("returns a helpful error", func() {
-				_, err := client.GetSubjectSpace("some-token", "some-subject-id", space)
+				_, err := client.GetSubjectSpace("some-token", "some-subject-id", spaceGUID)
 				Expect(err).To(MatchError(ContainSubstring("json client do: banana")))
 			})
 		})

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fakes/cc_client.go
@@ -91,20 +91,6 @@ type CCClient struct {
 		result1 cc_client.GetSecurityGroupsResponse
 		result2 error
 	}
-	GetSpaceStub        func(string, string) (*cc_client.SpaceResponse, error)
-	getSpaceMutex       sync.RWMutex
-	getSpaceArgsForCall []struct {
-		arg1 string
-		arg2 string
-	}
-	getSpaceReturns struct {
-		result1 *cc_client.SpaceResponse
-		result2 error
-	}
-	getSpaceReturnsOnCall map[int]struct {
-		result1 *cc_client.SpaceResponse
-		result2 error
-	}
 	GetSpaceGUIDsStub        func(string, []string) ([]string, error)
 	getSpaceGUIDsMutex       sync.RWMutex
 	getSpaceGUIDsArgsForCall []struct {
@@ -119,19 +105,19 @@ type CCClient struct {
 		result1 []string
 		result2 error
 	}
-	GetSubjectSpaceStub        func(string, string, cc_client.SpaceResponse) (*cc_client.SpaceResource, error)
+	GetSubjectSpaceStub        func(string, string, string) (*cc_client.RolesV3Resource, error)
 	getSubjectSpaceMutex       sync.RWMutex
 	getSubjectSpaceArgsForCall []struct {
 		arg1 string
 		arg2 string
-		arg3 cc_client.SpaceResponse
+		arg3 string
 	}
 	getSubjectSpaceReturns struct {
-		result1 *cc_client.SpaceResource
+		result1 *cc_client.RolesV3Resource
 		result2 error
 	}
 	getSubjectSpaceReturnsOnCall map[int]struct {
-		result1 *cc_client.SpaceResource
+		result1 *cc_client.RolesV3Resource
 		result2 error
 	}
 	GetSubjectSpacesStub        func(string, string) (map[string]struct{}, error)
@@ -555,71 +541,6 @@ func (fake *CCClient) GetSecurityGroupsWithPageReturnsOnCall(i int, result1 cc_c
 	}{result1, result2}
 }
 
-func (fake *CCClient) GetSpace(arg1 string, arg2 string) (*cc_client.SpaceResponse, error) {
-	fake.getSpaceMutex.Lock()
-	ret, specificReturn := fake.getSpaceReturnsOnCall[len(fake.getSpaceArgsForCall)]
-	fake.getSpaceArgsForCall = append(fake.getSpaceArgsForCall, struct {
-		arg1 string
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.GetSpaceStub
-	fakeReturns := fake.getSpaceReturns
-	fake.recordInvocation("GetSpace", []interface{}{arg1, arg2})
-	fake.getSpaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *CCClient) GetSpaceCallCount() int {
-	fake.getSpaceMutex.RLock()
-	defer fake.getSpaceMutex.RUnlock()
-	return len(fake.getSpaceArgsForCall)
-}
-
-func (fake *CCClient) GetSpaceCalls(stub func(string, string) (*cc_client.SpaceResponse, error)) {
-	fake.getSpaceMutex.Lock()
-	defer fake.getSpaceMutex.Unlock()
-	fake.GetSpaceStub = stub
-}
-
-func (fake *CCClient) GetSpaceArgsForCall(i int) (string, string) {
-	fake.getSpaceMutex.RLock()
-	defer fake.getSpaceMutex.RUnlock()
-	argsForCall := fake.getSpaceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *CCClient) GetSpaceReturns(result1 *cc_client.SpaceResponse, result2 error) {
-	fake.getSpaceMutex.Lock()
-	defer fake.getSpaceMutex.Unlock()
-	fake.GetSpaceStub = nil
-	fake.getSpaceReturns = struct {
-		result1 *cc_client.SpaceResponse
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *CCClient) GetSpaceReturnsOnCall(i int, result1 *cc_client.SpaceResponse, result2 error) {
-	fake.getSpaceMutex.Lock()
-	defer fake.getSpaceMutex.Unlock()
-	fake.GetSpaceStub = nil
-	if fake.getSpaceReturnsOnCall == nil {
-		fake.getSpaceReturnsOnCall = make(map[int]struct {
-			result1 *cc_client.SpaceResponse
-			result2 error
-		})
-	}
-	fake.getSpaceReturnsOnCall[i] = struct {
-		result1 *cc_client.SpaceResponse
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *CCClient) GetSpaceGUIDs(arg1 string, arg2 []string) ([]string, error) {
 	var arg2Copy []string
 	if arg2 != nil {
@@ -690,13 +611,13 @@ func (fake *CCClient) GetSpaceGUIDsReturnsOnCall(i int, result1 []string, result
 	}{result1, result2}
 }
 
-func (fake *CCClient) GetSubjectSpace(arg1 string, arg2 string, arg3 cc_client.SpaceResponse) (*cc_client.SpaceResource, error) {
+func (fake *CCClient) GetSubjectSpace(arg1 string, arg2 string, arg3 string) (*cc_client.RolesV3Resource, error) {
 	fake.getSubjectSpaceMutex.Lock()
 	ret, specificReturn := fake.getSubjectSpaceReturnsOnCall[len(fake.getSubjectSpaceArgsForCall)]
 	fake.getSubjectSpaceArgsForCall = append(fake.getSubjectSpaceArgsForCall, struct {
 		arg1 string
 		arg2 string
-		arg3 cc_client.SpaceResponse
+		arg3 string
 	}{arg1, arg2, arg3})
 	stub := fake.GetSubjectSpaceStub
 	fakeReturns := fake.getSubjectSpaceReturns
@@ -717,41 +638,41 @@ func (fake *CCClient) GetSubjectSpaceCallCount() int {
 	return len(fake.getSubjectSpaceArgsForCall)
 }
 
-func (fake *CCClient) GetSubjectSpaceCalls(stub func(string, string, cc_client.SpaceResponse) (*cc_client.SpaceResource, error)) {
+func (fake *CCClient) GetSubjectSpaceCalls(stub func(string, string, string) (*cc_client.RolesV3Resource, error)) {
 	fake.getSubjectSpaceMutex.Lock()
 	defer fake.getSubjectSpaceMutex.Unlock()
 	fake.GetSubjectSpaceStub = stub
 }
 
-func (fake *CCClient) GetSubjectSpaceArgsForCall(i int) (string, string, cc_client.SpaceResponse) {
+func (fake *CCClient) GetSubjectSpaceArgsForCall(i int) (string, string, string) {
 	fake.getSubjectSpaceMutex.RLock()
 	defer fake.getSubjectSpaceMutex.RUnlock()
 	argsForCall := fake.getSubjectSpaceArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *CCClient) GetSubjectSpaceReturns(result1 *cc_client.SpaceResource, result2 error) {
+func (fake *CCClient) GetSubjectSpaceReturns(result1 *cc_client.RolesV3Resource, result2 error) {
 	fake.getSubjectSpaceMutex.Lock()
 	defer fake.getSubjectSpaceMutex.Unlock()
 	fake.GetSubjectSpaceStub = nil
 	fake.getSubjectSpaceReturns = struct {
-		result1 *cc_client.SpaceResource
+		result1 *cc_client.RolesV3Resource
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *CCClient) GetSubjectSpaceReturnsOnCall(i int, result1 *cc_client.SpaceResource, result2 error) {
+func (fake *CCClient) GetSubjectSpaceReturnsOnCall(i int, result1 *cc_client.RolesV3Resource, result2 error) {
 	fake.getSubjectSpaceMutex.Lock()
 	defer fake.getSubjectSpaceMutex.Unlock()
 	fake.GetSubjectSpaceStub = nil
 	if fake.getSubjectSpaceReturnsOnCall == nil {
 		fake.getSubjectSpaceReturnsOnCall = make(map[int]struct {
-			result1 *cc_client.SpaceResource
+			result1 *cc_client.RolesV3Resource
 			result2 error
 		})
 	}
 	fake.getSubjectSpaceReturnsOnCall[i] = struct {
-		result1 *cc_client.SpaceResource
+		result1 *cc_client.RolesV3Resource
 		result2 error
 	}{result1, result2}
 }
@@ -836,8 +757,6 @@ func (fake *CCClient) Invocations() map[string][][]interface{} {
 	defer fake.getSecurityGroupsLastUpdateMutex.RUnlock()
 	fake.getSecurityGroupsWithPageMutex.RLock()
 	defer fake.getSecurityGroupsWithPageMutex.RUnlock()
-	fake.getSpaceMutex.RLock()
-	defer fake.getSpaceMutex.RUnlock()
 	fake.getSpaceGUIDsMutex.RLock()
 	defer fake.getSpaceGUIDsMutex.RUnlock()
 	fake.getSubjectSpaceMutex.RLock()

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/space.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/space.go
@@ -1,40 +1,48 @@
 package fixtures
 
 const Space = `{
-  "metadata": {
-    "guid": "bc8d3381-390d-4bd7-8c71-25309900a2e3",
-    "url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3",
-    "created_at": "2016-06-08T16:41:40Z",
-    "updated_at": "2016-06-08T16:41:26Z"
-  },
-  "entity": {
-    "name": "name-2064",
-    "organization_guid": "6e1ca5aa-55f1-4110-a97f-1f3473e771b9",
-    "space_quota_definition_guid": null,
-    "allow_ssh": true,
-    "organization_url": "/v2/organizations/6e1ca5aa-55f1-4110-a97f-1f3473e771b9",
-    "developers_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/developers",
-    "managers_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/managers",
-    "auditors_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/auditors",
-    "apps_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/apps",
-    "routes_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/routes",
-    "domains_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/domains",
-    "service_instances_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/service_instances",
-    "app_events_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/app_events",
-    "events_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/events",
-    "security_groups_url": "/v2/spaces/bc8d3381-390d-4bd7-8c71-25309900a2e3/security_groups"
-  }
+  "resources": [
+    {
+      "guid": "some-space-guid",
+      "name": "some-space-name",
+      "relationships": {
+        "organization": {
+          "data": {
+            "guid": "6e1ca5aa-55f1-4110-a97f-1f3473e771b9"
+          }
+        }
+      }
+    }
+  ]
 }`
 
 const Space1 = `{
-  "entity": {
-    "name": "space-1",
-    "organization_guid": "org-1-guid"
-  }
+  "resources": [
+    {
+      "guid": "space-1-guid",
+      "name": "space-1",
+      "relationships": {
+        "organization": {
+          "data": {
+            "guid": "org-1-guid"
+          }
+        }
+      }
+    }
+  ]
 }`
 const Space2 = `{
-  "entity": {
-    "name": "space-2",
-    "organization_guid": "org-1-guid"
-  }
+  "resources": [
+    {
+      "guid": "space-2-guid",
+      "name": "space-2",
+      "relationships": {
+        "organization": {
+          "data": {
+            "guid": "org-1-guid"
+          }
+        }
+      }
+    }
+  ]
 }`

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/spaces.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/spaces.go
@@ -81,7 +81,7 @@ const SpaceV3LiveSpaces = `{
          "relationships": {
             "organization": {
                "data": {
-                  "guid": "3638bc38-4e7a-45c9-8119-40af6f58b088"
+                  "guid": "org-1-guid"
                }
             }
          }
@@ -94,12 +94,44 @@ const SpaceV3LiveSpaces = `{
          "relationships": {
             "organization": {
                "data": {
-                  "guid": "3638bc38-4e7a-45c9-8119-40af6f58b088"
+                  "guid": "org-1-guid"
                }
             }
          }
       }
    ]
+}`
+
+const SpaceV3LiveSpace1 = `{
+   "resources": [
+      {
+         "guid": "space-1-guid",
+         "name": "space-1",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "org-1-guid"
+               }
+            }
+         }
+      }
+    ]
+}`
+
+const SpaceV3LiveSpace2 = `{
+   "resources": [
+      {
+         "guid": "space-2-guid",
+         "name": "space-2",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "org-1-guid"
+               }
+            }
+         }
+      }
+    ]
 }`
 
 const SpaceV3MultiplePages = `{

--- a/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/user_space.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/fixtures/user_space.go
@@ -1,37 +1,39 @@
 package fixtures
 
 const SubjectSpace = `{
-  "total_results": 1,
-  "total_pages": 1,
-  "prev_url": null,
-  "next_url": null,
-  "resources": [
-    {
-      "metadata": {
-        "guid": "2e100106-0b74-4062-8671-0d375f951cb4",
-        "url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
-      },
-      "entity": {
-        "name": "some-space-name",
-        "organization_guid": "some-org-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/some-org-guid",
-        "developers_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/developers",
-        "managers_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/managers",
-        "auditors_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/auditors",
-        "apps_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/apps",
-        "routes_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/routes",
-        "domains_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/domains",
-        "service_instances_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/service_instances",
-        "app_events_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/app_events",
-        "events_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/events",
-        "security_groups_url": "/v2/spaces/2e100106-0b74-4062-8671-0d375f951cb4/security_groups"
+  "guid": "885735b5-aea4-4cf5-8e44-961af0e41920",
+  "created_at": "2017-02-01T01:33:58Z",
+  "updated_at": "2017-02-01T01:33:58Z",
+  "name": "some-space-name,
+  "relationships": {
+    "organization": {
+      "data": {
+        "guid": "e00705b9-7b42-4561-ae97-2520399d2133"
       }
+    },
+    "quota": {
+      "data": null
     }
-  ]
+  },
+  "links": {
+    "self": {
+      "href": "https://api.example.org/v3/spaces/885735b5-aea4-4cf5-8e44-961af0e41920"
+    },
+    "features": {
+      "href": "https://api.example.org/v3/spaces/885735b5-aea4-4cf5-8e44-961af0e41920/features"
+    },
+    "organization": {
+      "href": "https://api.example.org/v3/organizations/e00705b9-7b42-4561-ae97-2520399d2133"
+    },
+    "apply_manifest": {
+      "href": "https://api.example.org/v3/spaces/885735b5-aea4-4cf5-8e44-961af0e41920/actions/apply_manifest",
+      "method": "POST"
+    }
+  },
+  "metadata": {
+    "labels": {},
+    "annotations": {}
+  }
 }`
 
 const SubjectSpaceEmpty = `{
@@ -43,160 +45,221 @@ const SubjectSpaceEmpty = `{
 }`
 
 const SubjectSpaces = `{
-  "total_results": 2,
-  "total_pages": 1,
-  "prev_url": null,
-  "next_url": null,
-  "resources": [
-    {
-      "metadata": {
-        "guid": "space-1-guid",
-        "url": "/v2/spaces/space-1-guid",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
+   "resources": [
+      {
+         "guid": "guid-1",
+         "type": "space_developer",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "org-2-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-1-guid"
+               }
+            }
+         }
       },
-      "entity": {
-        "name": "space-1-name",
-        "organization_guid": "org-1-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/org-1-guid",
-        "developers_url": "/v2/spaces/space-1-guid/developers",
-        "managers_url": "/v2/spaces/space-1-guid/managers",
-        "auditors_url": "/v2/spaces/space-1-guid/auditors",
-        "apps_url": "/v2/spaces/space-1-guid/apps",
-        "routes_url": "/v2/spaces/space-1-guid/routes",
-        "domains_url": "/v2/spaces/space-1-guid/domains",
-        "service_instances_url": "/v2/spaces/space-1-guid/service_instances",
-        "app_events_url": "/v2/spaces/space-1-guid/app_events",
-        "events_url": "/v2/spaces/space-1-guid/events",
-        "security_groups_url": "/v2/spaces/space-1-guid/security_groups"
+      {
+         "guid": "guid-2",
+         "type": "space_developer",
+         "relationships": {
+            "organization": {
+               "data": {
+		  "guid": "org-2-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-2-guid"
+               }
+            }
+         }
       }
-    },
-    {
-      "metadata": {
-        "guid": "space-2-guid",
-        "url": "/v2/spaces/space-2-guid",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
-      },
-      "entity": {
-        "name": "space-2-name",
-        "organization_guid": "org-2-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/org-2-guid",
-        "developers_url": "/v2/spaces/space-2-guid/developers",
-        "managers_url": "/v2/spaces/space-2-guid/managers",
-        "auditors_url": "/v2/spaces/space-2-guid/auditors",
-        "apps_url": "/v2/spaces/space-2-guid/apps",
-        "routes_url": "/v2/spaces/space-2-guid/routes",
-        "domains_url": "/v2/spaces/space-2-guid/domains",
-        "service_instances_url": "/v2/spaces/space-2-guid/service_instances",
-        "app_events_url": "/v2/spaces/space-2-guid/app_events",
-        "events_url": "/v2/spaces/space-2-guid/events",
-        "security_groups_url": "/v2/spaces/space-2-guid/security_groups"
+   ]
+}`
+
+const SubjectSpace1 = `{
+   "resources": [
+      {
+         "guid": "guid-1",
+         "type": "space_developer",
+         "relationships": {
+            "organization": {
+               "data": {
+                  "guid": "org-2-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-1-guid"
+               }
+            }
+         }
       }
-    }
   ]
 }`
 
+const SubjectSpace2 = `{}`
+
 const SubjectSpacesPage1 = `{
-  "total_results": 3,
-  "total_pages": 3,
-  "prev_url": null,
-  "next_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=2&results-per-page=1",
-  "resources": [
-    {
-      "metadata": {
-        "guid": "space-1-guid",
-        "url": "/v2/spaces/space-1-guid",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
+   "pagination": {
+      "total_results": 3,
+      "total_pages": 3,
+      "first": {
+         "href": "https://api.example.org/v3/roles?page=1&per_page=2"
       },
-      "entity": {
-        "name": "space-1-name",
-        "organization_guid": "org-1-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/org-1-guid",
-        "developers_url": "/v2/spaces/space-1-guid/developers",
-        "managers_url": "/v2/spaces/space-1-guid/managers",
-        "auditors_url": "/v2/spaces/space-1-guid/auditors",
-        "apps_url": "/v2/spaces/space-1-guid/apps",
-        "routes_url": "/v2/spaces/space-1-guid/routes",
-        "domains_url": "/v2/spaces/space-1-guid/domains",
-        "service_instances_url": "/v2/spaces/space-1-guid/service_instances",
-        "app_events_url": "/v2/spaces/space-1-guid/app_events",
-        "events_url": "/v2/spaces/space-1-guid/events",
-        "security_groups_url": "/v2/spaces/space-1-guid/security_groups"
+      "last": {
+         "href": "https://api.example.org/v3/roles?page=3&per_page=2"
+      },
+      "next": {
+         "href": "https://api.example.org/v3/roles?page=2&per_page=2"
+      },
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "40557c70-d1bd-4976-a2ab-a85f5e882418",
+         "created_at": "2019-10-10T17:19:12Z",
+         "updated_at": "2019-10-10T17:19:12Z",
+         "type": "organization_auditor",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "59eadb5f-fc13-414f-84ba-77a35e239cc8"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-1-guid"
+               }
+            }
+         },
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/roles/40557c70-d1bd-4976-a2ab-a85f5e882418"
+            },
+            "user": {
+               "href": "https://api.example.org/v3/users/59eadb5f-fc13-414f-84ba-77a35e239cc8"
+            },
+            "organization": {
+               "href": "https://api.example.org/v3/organizations/05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+            }
+         }
       }
-    }
-  ]
+   ]
 }`
 const SubjectSpacesPage2 = `{
-  "total_results": 3,
-  "total_pages": 3,
-  "prev_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=1&results-per-page=1",
-  "next_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=3&results-per-page=1",
-  "resources": [
-    {
-      "metadata": {
-        "guid": "space-2-guid",
-        "url": "/v2/spaces/space-2-guid",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
+   "pagination": {
+      "total_results": 3,
+      "total_pages": 3,
+      "first": {
+         "href": "https://api.example.org/v3/roles?page=1&per_page=2"
       },
-      "entity": {
-        "name": "space-2-name",
-        "organization_guid": "org-2-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/org-2-guid",
-        "developers_url": "/v2/spaces/space-2-guid/developers",
-        "managers_url": "/v2/spaces/space-2-guid/managers",
-        "auditors_url": "/v2/spaces/space-2-guid/auditors",
-        "apps_url": "/v2/spaces/space-2-guid/apps",
-        "routes_url": "/v2/spaces/space-2-guid/routes",
-        "domains_url": "/v2/spaces/space-2-guid/domains",
-        "service_instances_url": "/v2/spaces/space-2-guid/service_instances",
-        "app_events_url": "/v2/spaces/space-2-guid/app_events",
-        "events_url": "/v2/spaces/space-2-guid/events",
-        "security_groups_url": "/v2/spaces/space-2-guid/security_groups"
+      "last": {
+         "href": "https://api.example.org/v3/roles?page=3&per_page=2"
+      },
+      "next": {
+         "href": "https://api.example.org/v3/roles?page=3&per_page=2"
+      },
+      "previous": {
+         "href": "https://api.example.org/v3/roles?page=1&per_page=2"
       }
-    }
-  ]
+   },
+   "resources": [
+      {
+         "guid": "40557c70-d1bd-4976-a2ab-a85f5e882418",
+         "created_at": "2019-10-10T17:19:12Z",
+         "updated_at": "2019-10-10T17:19:12Z",
+         "type": "organization_auditor",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "59eadb5f-fc13-414f-84ba-77a35e239cc8"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-2-guid"
+               }
+
+            }
+         },
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/roles/40557c70-d1bd-4976-a2ab-a85f5e882418"
+            },
+            "user": {
+               "href": "https://api.example.org/v3/users/59eadb5f-fc13-414f-84ba-77a35e239cc8"
+            },
+            "organization": {
+               "href": "https://api.example.org/v3/organizations/05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+            }
+         }
+      }
+   ]
 }`
 const SubjectSpacesPage3 = `{
-  "total_results": 3,
-  "total_pages": 3,
-  "prev_url": "/v2/users/some-subject-id/spaces?order-direction=asc&page=2&results-per-page=1",
-  "next_url": null,
-  "resources": [
-    {
-      "metadata": {
-        "guid": "space-3-guid",
-        "url": "/v2/spaces/space-3-guid",
-        "created_at": "2016-06-08T16:41:40Z",
-        "updated_at": "2016-06-08T16:41:26Z"
+   "pagination": {
+      "total_results": 3,
+      "total_pages": 3,
+      "first": {
+         "href": "https://api.example.org/v3/roles?page=1&per_page=2"
       },
-      "entity": {
-        "name": "space-3-name",
-        "organization_guid": "org-3-guid",
-        "space_quota_definition_guid": null,
-        "allow_ssh": true,
-        "organization_url": "/v2/organizations/org-3-guid",
-        "developers_url": "/v2/spaces/space-3-guid/developers",
-        "managers_url": "/v2/spaces/space-3-guid/managers",
-        "auditors_url": "/v2/spaces/space-3-guid/auditors",
-        "apps_url": "/v2/spaces/space-3-guid/apps",
-        "routes_url": "/v2/spaces/space-3-guid/routes",
-        "domains_url": "/v2/spaces/space-3-guid/domains",
-        "service_instances_url": "/v2/spaces/space-3-guid/service_instances",
-        "app_events_url": "/v2/spaces/space-3-guid/app_events",
-        "events_url": "/v2/spaces/space-3-guid/events",
-        "security_groups_url": "/v2/spaces/space-3-guid/security_groups"
+      "last": {
+         "href": "https://api.example.org/v3/roles?page=3&per_page=2"
+      },
+      "next": null,
+      "previous": {
+         "href": "https://api.example.org/v3/roles?page=2&per_page=2"
       }
-    }
-  ]
+   },
+   "resources": [
+      {
+         "guid": "40557c70-d1bd-4976-a2ab-a85f5e882418",
+         "created_at": "2019-10-10T17:19:12Z",
+         "updated_at": "2019-10-10T17:19:12Z",
+         "type": "organization_auditor",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "59eadb5f-fc13-414f-84ba-77a35e239cc8"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-3-guid"
+               }
+            }
+         },
+         "links": {
+            "self": {
+               "href": "https://api.example.org/v3/roles/40557c70-d1bd-4976-a2ab-a85f5e882418"
+            },
+            "user": {
+               "href": "https://api.example.org/v3/users/59eadb5f-fc13-414f-84ba-77a35e239cc8"
+            },
+            "organization": {
+               "href": "https://api.example.org/v3/organizations/05c5da3b-6cbc-421c-87c3-20bb3c41ab7c"
+            }
+         }
+      }
+   ]
 }`

--- a/src/code.cloudfoundry.org/policy-server/handlers/policy_guard.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/policy_guard.go
@@ -37,14 +37,7 @@ func (g *PolicyGuard) CheckAccess(policies []store.Policy, subjectToken uaa_clie
 		return false, fmt.Errorf("getting space guids: %s", err)
 	}
 	for _, guid := range spaceGUIDs {
-		space, err := g.CCClient.GetSpace(token, guid)
-		if err != nil {
-			return false, fmt.Errorf("getting space with guid %s: %s", guid, err)
-		}
-		if space == nil {
-			return false, nil
-		}
-		subjectSpace, err := g.CCClient.GetSubjectSpace(token, subjectToken.Subject, *space)
+		subjectSpace, err := g.CCClient.GetSubjectSpace(token, subjectToken.Subject, guid)
 		if err != nil {
 			return false, fmt.Errorf("getting space with guid %s: %s", guid, err)
 		}

--- a/src/code.cloudfoundry.org/policy-server/handlers/policy_guard_test.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/policy_guard_test.go
@@ -21,9 +21,6 @@ var _ = Describe("PolicyGuard", func() {
 		tokenData     uaa_client.CheckTokenResponse
 		policies      []store.Policy
 		spaceGUIDs    []string
-		space1        cc_client.SpaceResponse
-		space2        cc_client.SpaceResponse
-		space3        cc_client.SpaceResponse
 	)
 
 	BeforeEach(func() {
@@ -57,58 +54,31 @@ var _ = Describe("PolicyGuard", func() {
 			UserName: "some-developer",
 		}
 		spaceGUIDs = []string{"space-guid-1", "space-guid-2", "space-guid-3"}
-		space1 = cc_client.SpaceResponse{
-			Entity: cc_client.SpaceEntity{
-				Name:             "space-1",
-				OrganizationGUID: "org-guid-1",
-			},
-		}
-		space2 = cc_client.SpaceResponse{
-			Entity: cc_client.SpaceEntity{
-				Name:             "space-2",
-				OrganizationGUID: "org-guid-2",
-			}}
-		space3 = cc_client.SpaceResponse{
-			Entity: cc_client.SpaceEntity{
-				Name:             "space-3",
-				OrganizationGUID: "org-guid-3",
-			}}
 
 		fakeUAAClient.GetTokenReturns("policy-server-token", nil)
 		fakeCCClient.GetSpaceGUIDsReturns(spaceGUIDs, nil)
-		fakeCCClient.GetSpaceStub = func(token, spaceGUID string) (*cc_client.SpaceResponse, error) {
+		fakeCCClient.GetSubjectSpaceStub = func(token, subjectId string, spaceGUID string) (*cc_client.RolesV3Resource, error) {
 			switch spaceGUID {
-			case "space-guid-1":
+			case spaceGUIDs[0]:
 				{
-					return &space1, nil
+					r := &cc_client.RolesV3Resource{}
+					r.Relationships = cc_client.RoleRelationship{}
+					r.Relationships.Space.Data.GUID = spaceGUIDs[0]
+					return r, nil
 				}
-			case "space-guid-2":
+			case spaceGUIDs[1]:
 				{
-					return &space2, nil
+					r := &cc_client.RolesV3Resource{}
+					r.Relationships = cc_client.RoleRelationship{}
+					r.Relationships.Space.Data.GUID = spaceGUIDs[1]
+					return r, nil
 				}
-			case "space-guid-3":
+			case spaceGUIDs[2]:
 				{
-					return &space3, nil
-				}
-			default:
-				{
-					return nil, errors.New("stub called with unexpected guid")
-				}
-			}
-		}
-		fakeCCClient.GetSubjectSpaceStub = func(token, subjectId string, space cc_client.SpaceResponse) (*cc_client.SpaceResource, error) {
-			switch space {
-			case space1:
-				{
-					return &cc_client.SpaceResource{Entity: space1.Entity}, nil
-				}
-			case space2:
-				{
-					return &cc_client.SpaceResource{Entity: space2.Entity}, nil
-				}
-			case space3:
-				{
-					return &cc_client.SpaceResource{Entity: space3.Entity}, nil
+					r := &cc_client.RolesV3Resource{}
+					r.Relationships = cc_client.RoleRelationship{}
+					r.Relationships.Space.Data.GUID = spaceGUIDs[2]
+					return r, nil
 				}
 			default:
 				{
@@ -156,29 +126,19 @@ var _ = Describe("PolicyGuard", func() {
 			token, appGUIDs := fakeCCClient.GetSpaceGUIDsArgsForCall(0)
 			Expect(token).To(Equal("policy-server-token"))
 			Expect(appGUIDs).To(ConsistOf([]string{"some-app-guid", "some-other-guid", "yet-another-guid"}))
-			Expect(fakeCCClient.GetSpaceCallCount()).To(Equal(3))
-			token, guid := fakeCCClient.GetSpaceArgsForCall(0)
-			Expect(token).To(Equal("policy-server-token"))
-			Expect(guid).To(Equal("space-guid-1"))
-			token, guid = fakeCCClient.GetSpaceArgsForCall(1)
-			Expect(token).To(Equal("policy-server-token"))
-			Expect(guid).To(Equal("space-guid-2"))
-			token, guid = fakeCCClient.GetSpaceArgsForCall(2)
-			Expect(token).To(Equal("policy-server-token"))
-			Expect(guid).To(Equal("space-guid-3"))
 			Expect(fakeCCClient.GetSubjectSpaceCallCount()).To(Equal(3))
 			token, subjectId, checkSubjectSpace := fakeCCClient.GetSubjectSpaceArgsForCall(0)
 			Expect(token).To(Equal("policy-server-token"))
 			Expect(subjectId).To(Equal("some-developer-guid"))
-			Expect(checkSubjectSpace).To(Equal(space1))
+			Expect(checkSubjectSpace).To(Equal(spaceGUIDs[0]))
 			token, subjectId, checkSubjectSpace = fakeCCClient.GetSubjectSpaceArgsForCall(1)
 			Expect(token).To(Equal("policy-server-token"))
 			Expect(subjectId).To(Equal("some-developer-guid"))
-			Expect(checkSubjectSpace).To(Equal(space2))
+			Expect(checkSubjectSpace).To(Equal(spaceGUIDs[1]))
 			token, subjectId, checkSubjectSpace = fakeCCClient.GetSubjectSpaceArgsForCall(2)
 			Expect(token).To(Equal("policy-server-token"))
 			Expect(subjectId).To(Equal("some-developer-guid"))
-			Expect(checkSubjectSpace).To(Equal(space3))
+			Expect(checkSubjectSpace).To(Equal(spaceGUIDs[2]))
 			Expect(authorized).To(BeTrue())
 		})
 
@@ -198,29 +158,19 @@ var _ = Describe("PolicyGuard", func() {
 				token, appGUIDs := fakeCCClient.GetSpaceGUIDsArgsForCall(0)
 				Expect(token).To(Equal("policy-server-token"))
 				Expect(appGUIDs).To(ConsistOf([]string{"some-app-guid", "some-other-guid", "yet-another-guid"}))
-				Expect(fakeCCClient.GetSpaceCallCount()).To(Equal(3))
-				token, guid := fakeCCClient.GetSpaceArgsForCall(0)
-				Expect(token).To(Equal("policy-server-token"))
-				Expect(guid).To(Equal("space-guid-1"))
-				token, guid = fakeCCClient.GetSpaceArgsForCall(1)
-				Expect(token).To(Equal("policy-server-token"))
-				Expect(guid).To(Equal("space-guid-2"))
-				token, guid = fakeCCClient.GetSpaceArgsForCall(2)
-				Expect(token).To(Equal("policy-server-token"))
-				Expect(guid).To(Equal("space-guid-3"))
 				Expect(fakeCCClient.GetSubjectSpaceCallCount()).To(Equal(3))
 				token, subjectId, checkSubjectSpace := fakeCCClient.GetSubjectSpaceArgsForCall(0)
 				Expect(token).To(Equal("policy-server-token"))
 				Expect(subjectId).To(Equal("some-client-id"))
-				Expect(checkSubjectSpace).To(Equal(space1))
+				Expect(checkSubjectSpace).To(Equal(spaceGUIDs[0]))
 				token, subjectId, checkSubjectSpace = fakeCCClient.GetSubjectSpaceArgsForCall(1)
 				Expect(token).To(Equal("policy-server-token"))
 				Expect(subjectId).To(Equal("some-client-id"))
-				Expect(checkSubjectSpace).To(Equal(space2))
+				Expect(checkSubjectSpace).To(Equal(spaceGUIDs[1]))
 				token, subjectId, checkSubjectSpace = fakeCCClient.GetSubjectSpaceArgsForCall(2)
 				Expect(token).To(Equal("policy-server-token"))
 				Expect(subjectId).To(Equal("some-client-id"))
-				Expect(checkSubjectSpace).To(Equal(space3))
+				Expect(checkSubjectSpace).To(Equal(spaceGUIDs[2]))
 				Expect(authorized).To(BeTrue())
 			})
 		})
@@ -235,20 +185,8 @@ var _ = Describe("PolicyGuard", func() {
 				authorized, err := policyGuard.CheckAccess(policies, tokenData)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeUAAClient.GetTokenCallCount()).To(Equal(0))
-				Expect(fakeCCClient.GetSpaceCallCount()).To(Equal(0))
 				Expect(fakeCCClient.GetSubjectSpaceCallCount()).To(Equal(0))
 				Expect(authorized).To(BeTrue())
-			})
-		})
-
-		Context("when the getting one of the the spaces returns nil", func() {
-			BeforeEach(func() {
-				fakeCCClient.GetSpaceReturns(nil, nil)
-			})
-			It("returns false", func() {
-				authorized, err := policyGuard.CheckAccess(policies, tokenData)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(authorized).To(BeFalse())
 			})
 		})
 
@@ -281,17 +219,6 @@ var _ = Describe("PolicyGuard", func() {
 			It("returns a useful error", func() {
 				authorized, err := policyGuard.CheckAccess(policies, tokenData)
 				Expect(err).To(MatchError("getting space guids: banana"))
-				Expect(authorized).To(BeFalse())
-			})
-		})
-
-		Context("when the getting one of the the spaces fails", func() {
-			BeforeEach(func() {
-				fakeCCClient.GetSpaceReturns(nil, errors.New("banana"))
-			})
-			It("returns a useful error", func() {
-				authorized, err := policyGuard.CheckAccess(policies, tokenData)
-				Expect(err).To(MatchError("getting space with guid space-guid-1: banana"))
 				Expect(authorized).To(BeFalse())
 			})
 		})

--- a/src/code.cloudfoundry.org/policy-server/integration/helpers/helpers.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/helpers/helpers.go
@@ -64,44 +64,50 @@ var MockCCServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWrite
 	}
 
 	if r.URL.Path == "/v3/spaces" {
-		w.WriteHeader(http.StatusOK)
-		// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
-		w.Write([]byte(fixtures.SpaceV3LiveSpaces))
+		if strings.Contains(r.URL.RawQuery, "space-1") {
+			w.WriteHeader(http.StatusOK)
+			// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
+			w.Write([]byte(fixtures.SpaceV3LiveSpace1))
+		} else if strings.Contains(r.URL.RawQuery, "space-2") {
+			w.WriteHeader(http.StatusOK)
+			// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
+			w.Write([]byte(fixtures.SpaceV3LiveSpace2))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
+			w.Write([]byte(fixtures.SpaceV3LiveSpaces))
+		}
 		return
 	}
 
-	if r.URL.Path == "/v2/spaces/space-1-guid" {
+	if r.URL.Path == "/v3/spaces/space-1-guid" {
 		w.WriteHeader(http.StatusOK)
 		// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
 		w.Write([]byte(fixtures.Space1))
 		return
 	}
-	if r.URL.Path == "/v2/spaces/space-2-guid" {
+	if r.URL.Path == "/v3/spaces/space-2-guid" {
 		w.WriteHeader(http.StatusOK)
 		// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
 		w.Write([]byte(fixtures.Space2))
 		return
 	}
 
-	if r.URL.Path == "/v2/spaces" {
-		if strings.Contains(r.URL.RawQuery, "space-1") {
-			w.WriteHeader(http.StatusOK)
-			// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
-			w.Write([]byte(fixtures.SubjectSpace))
-			return
-		}
-		if strings.Contains(r.URL.RawQuery, "space-2") {
-			w.WriteHeader(http.StatusOK)
-			// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
-			w.Write([]byte(fixtures.SubjectSpaceEmpty))
-			return
-		}
-	}
-
-	if r.URL.Path == "/v2/users/some-user-or-client-id/spaces" {
+	if r.URL.Path == "/v3/roles" && !r.URL.Query().Has("types") {
 		w.WriteHeader(http.StatusOK)
 		// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
 		w.Write([]byte(fixtures.SubjectSpaces))
+		return
+	}
+
+	if r.URL.Path == "/v3/roles" && r.URL.Query().Has("types") {
+		w.WriteHeader(http.StatusOK)
+		spaces := map[string]string{
+			"space-1-guid": fixtures.SubjectSpace1,
+			"space-2-guid": fixtures.SubjectSpace2,
+		}
+		// #nosec G104 - ignore errors writing http responses to avoid spamming logs during a DoS
+		w.Write([]byte(spaces[r.URL.Query().Get("space_guids")]))
 		return
 	}
 

--- a/src/code.cloudfoundry.org/test/acceptance/asg_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/asg_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Application Security Groups", func() {
 
 	It("applies security group changes", func() {
 		internalCCPort := 9024
-		proxyRequestURL := fmt.Sprintf("http://%s.%s/proxy/cloud-controller-ng.service.cf.internal:%d/v2/info?protocol=https", appName, testConfig.AppsDomain, internalCCPort)
+		proxyRequestURL := fmt.Sprintf("http://%s.%s/proxy/cloud-controller-ng.service.cf.internal:%d/info?protocol=https", appName, testConfig.AppsDomain, internalCCPort)
 
 		By("checking that our app can't initially reach cloud controller over internal address")
 		resp, err := http.Get(proxyRequestURL)
@@ -94,7 +94,7 @@ var _ = Describe("Application Security Groups", func() {
 			Expect(err).ToNot(HaveOccurred())
 			resp.Body.Close()
 			return string(respBytes)
-		}).WithTimeout(180 * time.Second).Should(MatchRegexp("api_version"))
+		}).WithTimeout(180 * time.Second).Should(MatchRegexp("version"))
 
 		By("unbinding the security group")
 		Expect(cfCLI.UnbindSecurityGroup(asgName, orgName, spaceName)).To(Succeed())
@@ -109,7 +109,7 @@ var _ = Describe("Application Security Groups", func() {
 			Expect(err).ToNot(HaveOccurred())
 			resp.Body.Close()
 			response := string(respBytes)
-			Expect(response).To(MatchRegexp("api_version"))
+			Expect(response).To(MatchRegexp("version"))
 
 			Expect(cf.Cf("restart", appName).Wait(Timeout_Push)).To(gexec.Exit(0))
 		}

--- a/src/code.cloudfoundry.org/test/acceptance/init_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/init_test.go
@@ -83,7 +83,7 @@ func Auth(username, password string) {
 }
 
 func getUAABaseURL() string {
-	sess := cf.Cf("curl", "/v2/info")
+	sess := cf.Cf("curl", "/info")
 	Eventually(sess.Wait(Timeout_Short)).Should(gexec.Exit(0))
 	var response struct {
 		TokenEndpoint string `json:"token_endpoint"`
@@ -147,27 +147,33 @@ func waitForAllInstancesToBeRunning(appName string) {
 	appGuidSession := cf.Cf("app", appName, "--guid")
 	Expect(appGuidSession.Wait(Timeout_Short)).To(gexec.Exit(0))
 
-	capiURL := fmt.Sprintf("v2/apps/%s/instances", strings.TrimSpace(string(appGuidSession.Out.Contents())))
+	capiURL := fmt.Sprintf("/v3/apps/%s/processes/web/stats", strings.TrimSpace(string(appGuidSession.Out.Contents())))
 
-	type instanceInfo struct {
-		State string `json:"state"`
+	type stats struct {
+		Resources []struct {
+			Routable bool   `json:"routable"`
+			State    string `json:"state"`
+		} `json:"resources"`
 	}
 
-	instances := make(map[string]instanceInfo)
+	var s stats
 
 	allInstancesRunning := func() bool {
 		session := cf.Cf("curl", capiURL)
 		Expect(session.Wait(Timeout_Short)).To(gexec.Exit(0))
 
-		json.Unmarshal(session.Out.Contents(), &instances)
-		Expect(instances).To(Not(BeEmpty()))
+		json.Unmarshal(session.Out.Contents(), &s)
+		Expect(s.Resources).NotTo(BeEmpty())
 
-		for _, instance := range instances {
-			if instance.State != "RUNNING" {
-				return false
+		running := false
+		for _, instance := range s.Resources {
+			if instance.State == "RUNNING" && instance.Routable {
+				running = true
+			} else {
+				running = false
 			}
 		}
-		return true
+		return running
 	}
 
 	Eventually(allInstancesRunning, "30s", "500ms").Should(Equal(true), "not all instances running")

--- a/src/code.cloudfoundry.org/test/acceptance/space_developer_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/space_developer_test.go
@@ -2,6 +2,7 @@ package acceptance_test
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 )
+
+const spaceClientID = "45733a09-a1c2-4990-b0ee-3e0428552c05"
 
 var _ = Describe("space developer policy configuration", func() {
 	var (
@@ -80,7 +83,7 @@ var _ = Describe("space developer policy configuration", func() {
 		Expect(cf.Cf("set-space-role", "space-developer", orgName, spaceNameB, "SpaceDeveloper").Wait(Timeout_Push)).To(gexec.Exit(0))
 
 		_, err = uaaAPI.CreateClient(uaa.Client{
-			ClientID:             "space-client",
+			ClientID:             spaceClientID,
 			ClientSecret:         "password",
 			DisplayName:          "space-client",
 			Authorities:          []string{"network.write", "cloud_controller.read"},
@@ -98,10 +101,58 @@ var _ = Describe("space developer policy configuration", func() {
 		spaceBGuid, err := cfCLI.SpaceGuid(spaceNameB)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(cf.Cf("curl", "-X", "PUT", fmt.Sprintf("/v2/organizations/%s/users/space-client", orgGuid)).Wait()).To(gexec.Exit(0))
+		type organization struct {
+			Data struct {
+				Guid string `json:"guid,omitempty"`
+			} `json:"data,omitempty"`
+		}
+		type space struct {
+			Data struct {
+				Guid string `json:"guid,omitempty"`
+			} `json:"data,omitempty"`
+		}
+		type role struct {
+			Type          string `json:"type"`
+			Relationships struct {
+				User struct {
+					Data struct {
+						Guid string `json:"guid"`
+					} `json:"data"`
+				} `json:"user"`
+				Organization *organization `json:"organization,omitempty"`
+				Space        *space        `json:"space,omitempty"`
+			} `json:"relationships"`
+		}
 
-		cf.Cf("curl", "-X", "PUT", fmt.Sprintf("/v2/spaces/%s/developers/space-client", spaceAGuid))
-		cf.Cf("curl", "-X", "PUT", fmt.Sprintf("/v2/spaces/%s/developers/space-client", spaceBGuid))
+		r := new(role)
+		r.Type = "organization_user"
+		r.Relationships.User.Data.Guid = spaceClientID
+		r.Relationships.Organization = &organization{}
+		r.Relationships.Organization.Data.Guid = orgGuid
+
+		body, err := json.Marshal(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cf.Cf("curl", "-X", "POST", "/v3/roles", "-d", string(body)).Wait()).To(gexec.Exit(0))
+
+		r1 := new(role)
+		r1.Type = "space_developer"
+		r1.Relationships.User.Data.Guid = spaceClientID
+		r1.Relationships.Space = &space{}
+		r1.Relationships.Space.Data.Guid = spaceAGuid
+		body, err = json.Marshal(r1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cf.Cf("curl", "-X", "POST", "/v3/roles", "-d", string(body)).Wait()).To(gexec.Exit(0))
+
+		r1 = new(role)
+		r1.Type = "space_developer"
+		r1.Relationships.User.Data.Guid = spaceClientID
+		r1.Relationships.Space = &space{}
+		r1.Relationships.Space.Data.Guid = spaceBGuid
+		body, err = json.Marshal(r1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cf.Cf("curl", "-X", "POST", "/v3/roles", "-d", string(body)).Wait()).To(gexec.Exit(0))
+
 	})
 
 	AfterEach(func() {
@@ -109,7 +160,7 @@ var _ = Describe("space developer policy configuration", func() {
 			Expect(cf.Cf("logout").Wait(Timeout_Push)).To(gexec.Exit(0))
 			Expect(cf.Cf("auth", config.AdminUser, config.AdminPassword).Wait(Timeout_Push)).To(gexec.Exit(0))
 
-			uaaAPI.DeleteClient("space-client")
+			uaaAPI.DeleteClient(spaceClientID)
 
 			Expect(cf.Cf("delete-org", orgName, "-f").Wait(Timeout_Push)).To(gexec.Exit(0))
 		})
@@ -190,7 +241,7 @@ var _ = Describe("space developer policy configuration", func() {
 			})
 		},
 			Entry("as a user", []string{"space-developer", "password"}),
-			Entry("as a service account", []string{"space-client", "password", "--client-credentials"}),
+			Entry("as a service account", []string{spaceClientID, "password", "--client-credentials"}),
 		)
 	})
 })


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
CAPI v2 is now removed. Use an endpoint that's supported.


Backward Compatibility
---------------
Breaking Change? **No**

