### PR TITLE
Increase default disk quota for example apps from 32m to 64m

### DIFF
--- a/src/example-apps/proxy/manifest.yml
+++ b/src/example-apps/proxy/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: proxy-app
     memory: 32M
-    disk_quota: 32M
+    disk_quota: 64M
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: proxy

--- a/src/example-apps/raw-response/manifest.yml
+++ b/src/example-apps/raw-response/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: raw-response
     memory: 32M
-    disk_quota: 32M
+    disk_quota: 64M
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: raw-response

--- a/src/example-apps/smoke/manifest.yml
+++ b/src/example-apps/smoke/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: smoke
     memory: 32M
-    disk_quota: 32M
+    disk_quota: 64M
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: smoke

--- a/src/example-apps/spammer/manifest.yml
+++ b/src/example-apps/spammer/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: spammer
   memory: 32M
-  disk_quota: 32M
+  disk_quota: 64M
   buildpacks: [go_buildpack]
   env:
     GOPACKAGENAME: example-apps/spammer

--- a/src/example-apps/tick/manifest.yml
+++ b/src/example-apps/tick/manifest.yml
@@ -2,7 +2,7 @@
 applications:
   - name: tick
     memory: 32M
-    disk_quota: 32M
+    disk_quota: 64M
     buildpacks: [go_buildpack]
     instances: 3
     env:


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We have a 32mb disk size quota on various example apps. For whatever reason, that's now not always big enough to build + push the app. Looks like we skate by with 16k of free disk in the container for the `proxy` app when it works. But it seems this is close enough that inevitably one or two tests are now repeatedly failing in cf-network-acceptance-tests. 


Backward Compatibility
---------------
Breaking Change? no
