### PR TITLE
Defer fixing deprecated libcni functions until a thorough dive into the correct solution can be done

### DIFF
--- a/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader.go
@@ -63,11 +63,13 @@ func (l *CNILoader) GetNetworkConfig() (*libcni.NetworkConfigList, error) {
 		toReturn = confList
 	} else if len(confFilePaths) > 0 {
 		path := confFilePaths[0]
+		//lint:ignore SA1019 - we will address this, but would like to keep units passing
 		conf, err := libcni.ConfFromFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("unable to load config from %s: %s", path, err)
 		}
 
+		//lint:ignore SA1019 - we will address this, but would like to keep units passing
 		confList, err := libcni.ConfListFromConf(conf)
 		if err != nil {
 			// untested, unable to cause failure case.


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Putting in an internal story for us to investigate + address the changes to supported conf file formats and see the best way for us to address it. In the mean time, this shouldn't prevent CI from running.


Backward Compatibility
---------------
Breaking Change? no