### PR TITLE
Add migrations to rollback the bad v0082 and v0083 migrations

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
@@ -450,4 +450,28 @@ var MigrationsToPerform = PolicyServerMigrations{
 		Id: "85",
 		Up: migration_v0085,
 	},
+	PolicyServerMigration{
+		Id: "86",
+		Up: migration_v0086,
+	},
+	PolicyServerMigration{
+		Id: "87",
+		Up: migration_v0087,
+	},
+	PolicyServerMigration{
+		Id: "88",
+		Up: migration_v0088,
+	},
+	PolicyServerMigration{
+		Id: "89",
+		Up: migration_v0089,
+	},
+	PolicyServerMigration{
+		Id: "90",
+		Up: migration_v0090,
+	},
+	PolicyServerMigration{
+		Id: "91",
+		Up: migration_v0091,
+	},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0082.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0082.go
@@ -1,8 +1,8 @@
 package migrations
 
 var migration_v0082 = map[string][]string{
-	"mysql": {
-		`CREATE INDEX staging_spaces_idx ON security_groups ((CAST(staging_spaces -> '$[*]' AS CHAR(36) ARRAY)))`,
-	},
+	"mysql": {},
+	// This ran into issues with index limits when ASGs are bound to > 148 spaces. Rolling it back.
+	//		`CREATE INDEX staging_spaces_idx ON security_groups ((CAST(staging_spaces -> '$[*]' AS CHAR(36) ARRAY)))`,
 	"postgres": {},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0083.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0083.go
@@ -1,8 +1,8 @@
 package migrations
 
 var migration_v0083 = map[string][]string{
-	"mysql": {
-		`CREATE INDEX running_spaces_idx ON security_groups ((CAST(running_spaces -> '$[*]' AS CHAR(36) ARRAY)))`,
-	},
+	"mysql": {},
+	// This ran into issues with index limits when ASGs are bound to > 148 spaces. Rolling it back.
+	//	`CREATE INDEX running_spaces_idx ON security_groups ((CAST(running_spaces -> '$[*]' AS CHAR(36) ARRAY)))`,
 	"postgres": {},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0086.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0086.go
@@ -1,0 +1,16 @@
+package migrations
+
+var migration_v0086 = map[string][]string{
+	"mysql": {
+		`CREATE PROCEDURE drop_running_spaces_index()
+			BEGIN
+				SET @exist := (select count(*) from information_schema.statistics where table_name = 'security_groups' and index_name = 'running_spaces_idx' and table_schema = database());
+				SET @sqlstmt := if( @exist <=> 0, 'select ''INFO: Index does not exist''', 'alter table security_groups drop index running_spaces_idx');
+				PREPARE stmt FROM @sqlstmt;
+				EXECUTE stmt;
+
+				DEALLOCATE PREPARE stmt;
+			END;`,
+	},
+	"postgres": {},
+}

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0087.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0087.go
@@ -1,0 +1,16 @@
+package migrations
+
+var migration_v0087 = map[string][]string{
+	"mysql": {
+		`CREATE PROCEDURE drop_staging_spaces_index()
+			BEGIN
+				SET @exist := (select count(*) from information_schema.statistics where table_name = 'security_groups' and index_name = 'staging_spaces_idx' and table_schema = database());
+				SET @sqlstmt := if( @exist <=> 0, 'select ''INFO: Index does not exist''', 'alter table security_groups drop index staging_spaces_idx');
+				PREPARE stmt FROM @sqlstmt;
+				EXECUTE stmt;
+
+				DEALLOCATE PREPARE stmt;
+			END;`,
+	},
+	"postgres": {},
+}

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0088.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0088.go
@@ -1,0 +1,8 @@
+package migrations
+
+var migration_v0088 = map[string][]string{
+	"mysql": {
+		`CALL drop_running_spaces_index();`,
+	},
+	"postgres": {},
+}

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0089.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0089.go
@@ -1,0 +1,8 @@
+package migrations
+
+var migration_v0089 = map[string][]string{
+	"mysql": {
+		`CALL drop_staging_spaces_index();`,
+	},
+	"postgres": {},
+}

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0090.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0090.go
@@ -1,0 +1,8 @@
+package migrations
+
+var migration_v0090 = map[string][]string{
+	"mysql": {
+		`DROP PROCEDURE drop_running_spaces_index;`,
+	},
+	"postgres": {},
+}

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0091.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0091.go
@@ -1,0 +1,8 @@
+package migrations
+
+var migration_v0091 = map[string][]string{
+	"mysql": {
+		`DROP PROCEDURE drop_staging_spaces_index;`,
+	},
+	"postgres": {},
+}


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Rollback migrations 82 and 83 to fix the following issue:

When running this version of CF Networking Release with dynamic ASGs enabled and with a MYSQL database, there is a known issue where ASGs bound to more than 148 running or staging spaces will cause failures. See [this doc](https://github.com/cloudfoundry/cf-networking-release/blob/develop/docs/12-known-issue-asgs-with-too-many-bound-spaces.md) for more information.


Backward Compatibility
---------------
Breaking Change? **No**