### PR TITLE
Fix flaky test by making sure ASG is gone first from previous test

### DIFF
--- a/src/code.cloudfoundry.org/test/acceptance/external_connectivity_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/external_connectivity_test.go
@@ -152,6 +152,7 @@ var _ = Describe("external connectivity", func() {
 			}
 
 			By("checking that the app cannot ping the internet")
+			Eventually(cannotPing, "10s", "1s").Should(Succeed())
 			Consistently(cannotPing, "2s", "0.5s").Should(Succeed())
 
 			By("creating and binding an icmp security group")


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Make sure ASG is gone, see the test above.


Backward Compatibility
---------------
Breaking Change? **No**
