### PR TITLE
Add a flag to skip acceptance tests that require app SSH

### DIFF
--- a/src/code.cloudfoundry.org/cf-pusher/config/config.go
+++ b/src/code.cloudfoundry.org/cf-pusher/config/config.go
@@ -25,5 +25,6 @@ type Config struct {
 	RunExperimentalOutboundConnLimitTest bool     `json:"run_experimental_outbound_conn_limit_test"`
 	SkipSpaceDeveloperPolicyTest         bool     `json:"skip_space_developer_policy_test"`
 	SkipSearchDomainTests                bool     `json:"skip_search_domain_tests"`
+	SkipSSHTests                         bool     `json:"skip_ssh_tests"`
 	SkipSSLValidation                    bool     `json:"skip_ssl_validation"`
 }

--- a/src/code.cloudfoundry.org/test/acceptance/README.md
+++ b/src/code.cloudfoundry.org/test/acceptance/README.md
@@ -34,6 +34,7 @@ Finally! A guide for how to run CF Networking Acceptance Tests!
 - `run_experimental_outbound_conn_limit_test`- Enables/Disables testing of the experimental option for outbound connection rate limiting.
 - `skip_space_developer_policy_test` - Unused.
 - `skip_search_domain_tests` - Disables/Enables tests to validate that search domains are propagated into the app containers' `/etc/resolv.conf`
+- `skip_ssh_tests` - Disables/Enables tests that require SSH access to app containers
 - `skip_ssl_validation` - Enables/Disables SSL validation when talking to CF + apps
 
 ## Recommended Config Options
@@ -42,7 +43,7 @@ Finally! A guide for how to run CF Networking Acceptance Tests!
 {
     "admin_password": "CF_ADMIN_PASSWORD",
     "admin_secret": "CF_ADMIN_UAA_SECRET",
-    "admin_user":"admin",
+    "admin_user": "admin",
     "api": "api.CF_SYSTEM_DOMAIN},
     "apps_domain": "CF_APPS_DOMAIN",
     "concurrency": 16,
@@ -51,19 +52,20 @@ Finally! A guide for how to run CF Networking Acceptance Tests!
     "extra_listen_ports": 2,
     "internetless": false,
     "nodes": 1,
-    "prefix":"test-",
+    "prefix": "test-",
     "proxy_applications": 1,
     "proxy_instances": 1,
     "run_custom_iptables_compatibility_test": true,
     "run_experimental_outbound_conn_limit_test": true,
     "skip_icmp_tests": false,
     "skip_search_domain_tests": false,
-    "skip_ssl_validation":true,
+    "skip_ssh_tests": false,
+    "skip_ssl_validation": true,
     "test_app_instances": 3,
     "test_applications": 2,
     "test_app_registry_ttl_seconds": 10,
     "include_security_groups": true,
-    "use_http":true
+    "use_http": true
 }
 ```
 

--- a/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
@@ -32,6 +32,10 @@ var _ = Describe("ASGs and Overlay Policy interaction", func() {
 		)
 
 		BeforeEach(func() {
+			if testConfig.SkipSSHTests {
+				Skip("skipping tests that require app SSH access")
+			}
+
 			appProxy = fmt.Sprintf("%s-%s-%d", testConfig.Prefix, "proxy", randomGenerator.Int31())
 			asgName = fmt.Sprintf("wide-open-asg-%d", randomGenerator.Int31())
 

--- a/src/code.cloudfoundry.org/test/acceptance/custom_iptables_compatibility_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/custom_iptables_compatibility_test.go
@@ -24,6 +24,10 @@ var _ = Describe("Custom iptables compatibility", func() {
 			Skip("skipping custom iptables compatibility tests")
 		}
 
+		if testConfig.SkipSSHTests {
+			Skip("skipping tests that require app SSH access")
+		}
+
 		appName = fmt.Sprintf("appA-%d", randomGenerator.Int31())
 
 		orgName = testConfig.Prefix + "custom-iptables-org"

--- a/src/code.cloudfoundry.org/test/acceptance/search_domains_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/search_domains_test.go
@@ -23,6 +23,10 @@ var _ = Describe("search domains", func() {
 			Skip("skipping search domains test")
 		}
 
+		if testConfig.SkipSSHTests {
+			Skip("skipping tests that require app SSH access")
+		}
+
 		appName = fmt.Sprintf("appName-%d", randomGenerator.Int31())
 		orgName = testConfig.Prefix + "search-domains-org"
 		setupOrgAndSpace(orgName, testConfig.Prefix+"space")

--- a/src/code.cloudfoundry.org/test/acceptance/source_ip_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/source_ip_test.go
@@ -19,6 +19,10 @@ var _ = Describe("c2c traffic source ip", func() {
 	)
 
 	BeforeEach(func() {
+		if testConfig.SkipSSHTests {
+			Skip("skipping tests that require app SSH access")
+		}
+
 		appName = fmt.Sprintf("appA-%d", randomGenerator.Int31())
 
 		orgName = testConfig.Prefix + "source-traffic-org"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR adds an optional configuration flag for the acceptance test suite that allows users to skip running tests that require app SSH to be enabled. The flag defaults to `false` to continue running all tests.

Backward Compatibility
---------------
Breaking Change? No
