### PR TITLE
Remove usage of CC's `cloud_controller_container_networking_info` and `internal_route_vip_range`

### DIFF
--- a/jobs/bosh-dns-adapter/spec
+++ b/jobs/bosh-dns-adapter/spec
@@ -18,9 +18,6 @@ packages:
 consumes:
   - name: service-discovery-controller
     type: service-discovery-controller
-  - name: cloud_controller_container_networking_info
-    type: cloud_controller_container_networking_info
-    optional: true
 
 properties:
   cf_app_sd_disable:
@@ -66,11 +63,6 @@ properties:
     description: "TLD for internal app resolution with istio service discovery."
     example: ["istio.apps.internal."]
     default: []
-
-  internal_route_vip_range:
-    description: "The ipv4 CIDR range of virtual IP addresses to be assigned to routes on internal domains.
-                  The value for this property should come from cloud_controller_container_networking_info
-                  link from capi-release. This property is here only for override purposes."
 
   healthchecker.failure_counter_file:
     description: "File used by the healthchecker to monitor consecutive failures."

--- a/jobs/bosh-dns-adapter/templates/config.json.erb
+++ b/jobs/bosh-dns-adapter/templates/config.json.erb
@@ -7,14 +7,6 @@ def internal_service_mesh_domains
   end
 end
 
-def internal_route_vip_range
-  if_p('internal_route_vip_range') do |prop|
-    return prop
-  end.else do
-    link('cloud_controller_container_networking_info').p('cc.internal_route_vip_range')
-  end
-end
-
 def parse_ip (ip, var_name)
   unless ip.empty?
       begin
@@ -41,7 +33,6 @@ config = {
     'log_level_address' => p('log_level_address'),
     'log_level_port' => p('log_level_port'),
     'internal_service_mesh_domains' => internal_service_mesh_domains,
-    'internal_route_vip_range' => internal_route_vip_range,
 }
 
 require 'json'

--- a/jobs/garden-cni/spec
+++ b/jobs/garden-cni/spec
@@ -8,10 +8,6 @@ templates:
 packages:
   - runc-cni
 
-consumes:
-  - name: cloud_controller_container_networking_info
-    type: cloud_controller_container_networking_info
-
 properties:
   cni_plugin_dir:
     description: "Directory containing CNI plugins."

--- a/jobs/garden-cni/templates/adapter.json.erb
+++ b/jobs/garden-cni/templates/adapter.json.erb
@@ -6,9 +6,6 @@
       if_p("experimental_proxy_redirect_cidr") do |cidr|
         return cidr unless cidr.nil? || cidr.empty?
       end
-      if_link('cloud_controller_container_networking_info') do |link|
-        return link.p("cc.internal_route_vip_range")
-      end
       ''
     end
 

--- a/spec/bosh-dns-adapter/bosh_dns_adapter_spec.rb
+++ b/spec/bosh-dns-adapter/bosh_dns_adapter_spec.rb
@@ -17,8 +17,7 @@ module Bosh::Template::Test
         ],
         'internal_service_mesh_domains' => [
           'myistio.internal.app.domain.'
-        ],
-        'internal_route_vip_range' => '127.128.0.0/8'
+        ]
       }
     end
 
@@ -51,12 +50,6 @@ module Bosh::Template::Test
             properties: {
               'port' => 1234
             }
-          ),
-          Link.new(
-            name: 'cloud_controller_container_networking_info',
-            properties: {
-              'cc' => {'internal_route_vip_range' => '192.168.0.1/24'}
-            }
           )
         ]
       end
@@ -76,7 +69,6 @@ module Bosh::Template::Test
           'service_discovery_controller_address' => 'service-discovery-controller.service.cf.internal',
           'service_discovery_controller_port' => '1234',
           'internal_service_mesh_domains' => [],
-          'internal_route_vip_range' => '192.168.0.1/24',
         })
       end
 
@@ -119,7 +111,6 @@ module Bosh::Template::Test
             'port' => '8053',
             'service_discovery_controller_address' => 'service-discovery-controller.service.cf.internal',
             'service_discovery_controller_port' => '1234',
-            'internal_route_vip_range' => '127.128.0.0/8',
             'internal_service_mesh_domains' => ['myistio.internal.app.domain.'],
           })
         end

--- a/spec/garden-cni/garden_cni_spec.rb
+++ b/spec/garden-cni/garden_cni_spec.rb
@@ -8,16 +8,6 @@ module Bosh::Template::Test
     let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
     let(:release) {ReleaseDir.new(release_path)}
     let(:job) {release.job('garden-cni')}
-    let(:links) do
-      [
-         Link.new(
-           name: 'cloud_controller_container_networking_info',
-           properties: {
-             'cc' => {'internal_route_vip_range' => '192.168.0.1/24'}
-           }
-         )
-      ]
-    end
 
     describe 'adapter.json.erb' do
       let(:template) {job.template('config/adapter.json')}
@@ -37,7 +27,7 @@ module Bosh::Template::Test
         end
 
         it 'creates a config/adapter.json from properties' do
-          clientConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links))
+          clientConfig = JSON.parse(template.render(merged_manifest_properties))
           expect(clientConfig).to eq({
             'cni_plugin_dir' => 'meow-plugin-dir',
             'cni_config_dir' => 'meow-config-dir',
@@ -53,25 +43,6 @@ module Bosh::Template::Test
             'proxy_uid' => 0,
             'enable_ingress_proxy_redirect' => true,
           })
-        end
-      end
-     
-      describe 'when accepting the value from the link' do
-        let(:merged_manifest_properties) do
-          {
-            'cni_plugin_dir' => 'meow-plugin-dir',
-            'cni_config_dir' => 'meow-config-dir',
-            'nat_port_range_start' => 1111,
-            'nat_port_range_size' => 5555,
-            'search_domains' => ['meow', 'woof', 'neopets'],
-            'experimental_enable_proxy_redirect' => true,
-            'experimental_enable_ingress_proxy_redirect' => true
-          }
-        end
-
-        it 'uses the value from the link' do
-          clientConfig = JSON.parse(template.render(merged_manifest_properties, consumes: links))
-          expect(clientConfig['proxy_redirect_cidr']).to eq('192.168.0.1/24')
         end
       end
 
@@ -111,7 +82,7 @@ module Bosh::Template::Test
         end
 
         it 'creates a config/adapter.json from properties' do
-          clientConfig = JSON.parse(template.render(merged_manifest_properties), consumes: links)
+          clientConfig = JSON.parse(template.render(merged_manifest_properties))
           expect(clientConfig).to eq({
             'cni_plugin_dir' => 'meow-plugin-dir',
             'cni_config_dir' => 'meow-config-dir',

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/config/config.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/config/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	LogLevelAddress                   string             `json:"log_level_address" validate:"nonzero"`
 	LogLevelPort                      int                `json:"log_level_port" validate:"min=1"`
 	InternalServiceMeshDomains        []string           `json:"internal_service_mesh_domains"`
-	InternalRouteVIPRange             string             `json:"internal_route_vip_range" validate:"cidr"`
 }
 
 func init() {
@@ -52,10 +51,4 @@ func NewConfig(configJSON []byte) (*Config, error) {
 	}
 
 	return adapterConfig, err
-}
-
-func (c *Config) GetInternalRouteVIPRangeCIDR() *net.IPNet {
-	// We can ignore the error because it's been validated
-	_, cidr, _ := net.ParseCIDR(c.InternalRouteVIPRange)
-	return cidr
 }

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/config/config_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/config/config_test.go
@@ -1,8 +1,6 @@
 package config_test
 
 import (
-	"net"
-
 	. "code.cloudfoundry.org/bosh-dns-adapter/config"
 
 	"encoding/json"
@@ -29,7 +27,6 @@ var _ = Describe("Config", func() {
 				"metrics_emit_seconds": 6,
 				"metron_port": 8080,
 				"log_level_address": "log-level-address",
-				"internal_route_vip_range": "127.128.0.0/24",
 				"log_level_port": 9090
 			}`)
 			parsedConfig, err = NewConfig(configJSON)
@@ -49,16 +46,6 @@ var _ = Describe("Config", func() {
 			Expect(parsedConfig.MetronPort).To(Equal(8080))
 			Expect(parsedConfig.LogLevelAddress).To(Equal("log-level-address"))
 			Expect(parsedConfig.LogLevelPort).To(Equal(9090))
-			Expect(parsedConfig.InternalRouteVIPRange).To(Equal("127.128.0.0/24"))
-		})
-
-		It("returns a parsed CIDR struct", func() {
-			cidr := parsedConfig.GetInternalRouteVIPRangeCIDR()
-			expectedCIDR := &net.IPNet{
-				IP:   net.IP{127, 128, 0, 0},
-				Mask: net.IPMask{255, 255, 255, 0},
-			}
-			Expect(cidr).To(Equal(expectedCIDR))
 		})
 	})
 
@@ -84,7 +71,6 @@ var _ = Describe("Config", func() {
 			"metrics_emit_seconds":                 678,
 			"log_level_address":                    "log_level_address",
 			"log_level_port":                       8081,
-			"internal_route_vip_range":             "127.0.0.0/8",
 		}
 	})
 
@@ -110,7 +96,6 @@ var _ = Describe("Config", func() {
 		Entry("invalid ca_cert", "ca_cert", "", "CACert: zero value"),
 		Entry("invalid log_level_address", "log_level_address", "", "LogLevelAddress: zero value"),
 		Entry("invalid log_level_port", "log_level_port", -2, "LogLevelPort: less than min"),
-		Entry("invalid internal_route_vip_range", "internal_route_vip_range", "321.12.12.0/8", "InternalRouteVIPRange: invalid CIDR address: 321.12.12.0/8"),
 	)
 
 })

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/main_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/main_test.go
@@ -33,7 +33,6 @@ var _ = Describe("Main", func() {
 		dnsAdapterPort                         string
 		fakeMetron                             metrics.FakeMetron
 		logLevelPort                           int
-		internalRouteVIPRange                  string
 	)
 
 	BeforeEach(func() {
@@ -58,7 +57,6 @@ var _ = Describe("Main", func() {
 		)}
 
 		dnsAdapterAddress = "127.0.0.1"
-		internalRouteVIPRange = "127.0.0.0/24"
 
 		dnsAdapterPort = fmt.Sprintf("%d", ports.PickAPort())
 		logLevelPort = ports.PickAPort()
@@ -93,8 +91,7 @@ var _ = Describe("Main", func() {
 			"metrics_emit_seconds": 2,
 			"log_level_port": %d,
 			"log_level_address": "127.0.0.1",
-			"internal_service_mesh_domains" : ["istio.local."],
-			"internal_route_vip_range": "%s"
+			"internal_service_mesh_domains" : ["istio.local."]
 		}`, dnsAdapterAddress,
 			dnsAdapterPort,
 			strings.TrimPrefix(urlParts[1], "//"),
@@ -104,7 +101,6 @@ var _ = Describe("Main", func() {
 			caFileName,
 			fakeMetron.Port(),
 			logLevelPort,
-			internalRouteVIPRange,
 		)
 
 		tempConfigFile, err = os.CreateTemp(os.TempDir(), "sd")

--- a/src/code.cloudfoundry.org/test/performance-sd/test_assets/manifest.yml
+++ b/src/code.cloudfoundry.org/test/performance-sd/test_assets/manifest.yml
@@ -65,7 +65,6 @@ instance_groups:
   jobs:
   - name: bosh-dns-adapter
     properties:
-      internal_route_vip_range: 127.128.0.0/9
       dnshttps:
         client:
           tls:


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We want to remove the `cloud_controller_container_networking_info` link from CAPI release and the usage of `internal_route_vip_range` in Cloud Controller.
cf-networking release is still consuming the link, which is why we need to remove it from here first.
I built a dev release for cf-networking with the changes in this PR, as well as a dev release of capi including the below mentioned changes (+removed the link completely) and deployed it to a BBL environment. CATS were green.

Please check whether it can be removed from your POV. Also please check whether I got all references.

Here is the initial issue: https://github.com/cloudfoundry/cloud_controller_ng/issues/3712

And those PRs will remove it from CAPI release and CC: 
https://github.com/cloudfoundry/cloud_controller_ng/pull/3761 
https://github.com/cloudfoundry/capi-release/pull/419

Backward Compatibility
---------------
Breaking Change? **Yes/No**
I suppose no if it is dead code.
