### PR TITLE
Update policy-server migration testing + remove mysql57 specific logic.

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/store/migrations/fakes/migrations_provider.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/fakes/migrations_provider.go
@@ -8,10 +8,9 @@ import (
 )
 
 type MigrationsProvider struct {
-	MigrationsToPerformStub        func(bool) (migrations.PolicyServerMigrations, error)
+	MigrationsToPerformStub        func() (migrations.PolicyServerMigrations, error)
 	migrationsToPerformMutex       sync.RWMutex
 	migrationsToPerformArgsForCall []struct {
-		arg1 bool
 	}
 	migrationsToPerformReturns struct {
 		result1 migrations.PolicyServerMigrations
@@ -25,18 +24,17 @@ type MigrationsProvider struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *MigrationsProvider) MigrationsToPerform(arg1 bool) (migrations.PolicyServerMigrations, error) {
+func (fake *MigrationsProvider) MigrationsToPerform() (migrations.PolicyServerMigrations, error) {
 	fake.migrationsToPerformMutex.Lock()
 	ret, specificReturn := fake.migrationsToPerformReturnsOnCall[len(fake.migrationsToPerformArgsForCall)]
 	fake.migrationsToPerformArgsForCall = append(fake.migrationsToPerformArgsForCall, struct {
-		arg1 bool
-	}{arg1})
+	}{})
 	stub := fake.MigrationsToPerformStub
 	fakeReturns := fake.migrationsToPerformReturns
-	fake.recordInvocation("MigrationsToPerform", []interface{}{arg1})
+	fake.recordInvocation("MigrationsToPerform", []interface{}{})
 	fake.migrationsToPerformMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -50,17 +48,10 @@ func (fake *MigrationsProvider) MigrationsToPerformCallCount() int {
 	return len(fake.migrationsToPerformArgsForCall)
 }
 
-func (fake *MigrationsProvider) MigrationsToPerformCalls(stub func(bool) (migrations.PolicyServerMigrations, error)) {
+func (fake *MigrationsProvider) MigrationsToPerformCalls(stub func() (migrations.PolicyServerMigrations, error)) {
 	fake.migrationsToPerformMutex.Lock()
 	defer fake.migrationsToPerformMutex.Unlock()
 	fake.MigrationsToPerformStub = stub
-}
-
-func (fake *MigrationsProvider) MigrationsToPerformArgsForCall(i int) bool {
-	fake.migrationsToPerformMutex.RLock()
-	defer fake.migrationsToPerformMutex.RUnlock()
-	argsForCall := fake.migrationsToPerformArgsForCall[i]
-	return argsForCall.arg1
 }
 
 func (fake *MigrationsProvider) MigrationsToPerformReturns(result1 migrations.PolicyServerMigrations, result2 error) {

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations.go
@@ -433,14 +433,12 @@ var MigrationsToPerform = PolicyServerMigrations{
 		Up: migration_v0081,
 	},
 	PolicyServerMigration{
-		Id:          "82",
-		Up:          migration_v0082,
-		SkipMySQL57: true,
+		Id: "82",
+		Up: migration_v0082,
 	},
 	PolicyServerMigration{
-		Id:          "83",
-		Up:          migration_v0083,
-		SkipMySQL57: true,
+		Id: "83",
+		Up: migration_v0083,
 	},
 	PolicyServerMigration{
 		Id: "84",

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider.go
@@ -13,7 +13,7 @@ type MigrationsProvider struct {
 	Store migrationStore
 }
 
-func (m *MigrationsProvider) MigrationsToPerform(mysql57 bool) (PolicyServerMigrations, error) {
+func (m *MigrationsProvider) MigrationsToPerform() (PolicyServerMigrations, error) {
 	policyServerMigrations := PolicyServerMigrations{}
 
 	hasV1, err := m.Store.HasV1MigrationOccurred()
@@ -67,12 +67,7 @@ func (m *MigrationsProvider) MigrationsToPerform(mysql57 bool) (PolicyServerMigr
 		)
 	}
 
-	for _, migration := range MigrationsToPerform {
-		if mysql57 && migration.SkipMySQL57 {
-			continue
-		}
-		policyServerMigrations = append(policyServerMigrations, migration)
-	}
+	policyServerMigrations = append(policyServerMigrations, MigrationsToPerform...)
 
 	return policyServerMigrations, nil
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Migrations Provider", func() {
 	})
 
 	It("returns a list of migrations to perform", func() {
-		migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
+		migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
 		Expect(err).ToNot(HaveOccurred())
 		expectedMigrations := migrations.PolicyServerMigrations{
 			migrations.V1ModifiedMigrationsToPerform[0],
@@ -47,42 +47,23 @@ var _ = Describe("Migrations Provider", func() {
 
 	It("returns a helpful error message for V1MigrationOccurred errors", func() {
 		migrationStore.HasV1MigrationOccurredReturns(false, errors.New("I AM ERROR"))
-		_, err := migrationsProvider.MigrationsToPerform(false)
+		_, err := migrationsProvider.MigrationsToPerform()
 
 		Expect(err).To(MatchError("failed to check V1 Migration status: I AM ERROR"))
 	})
 
 	It("returns a helpful error message for V2MigrationOccurred errors", func() {
 		migrationStore.HasV2MigrationOccurredReturns(false, errors.New("I AM ERROR"))
-		_, err := migrationsProvider.MigrationsToPerform(false)
+		_, err := migrationsProvider.MigrationsToPerform()
 
 		Expect(err).To(MatchError("failed to check V2 Migration status: I AM ERROR"))
 	})
 
 	It("returns a helpful error message for V3MigrationOccurred errors", func() {
 		migrationStore.HasV3MigrationOccurredReturns(false, errors.New("I AM ERROR"))
-		_, err := migrationsProvider.MigrationsToPerform(false)
+		_, err := migrationsProvider.MigrationsToPerform()
 
 		Expect(err).To(MatchError("failed to check V3 Migration status: I AM ERROR"))
-	})
-
-	Context("when a migration is set to skip on mysql 5.7", func() {
-		Context("and the database is not mysql 5.7", func() {
-			It("lists the migration", func() {
-				migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(migrationsToPerform).To(ContainElement(migrations.MigrationsToPerform[78]))
-				Expect(migrationsToPerform).To(ContainElement(migrations.MigrationsToPerform[79]))
-			})
-		})
-		Context("and the database is mysql 5.7", func() {
-			It("doesn't list the migration", func() {
-				migrationsToPerform, err := migrationsProvider.MigrationsToPerform(true)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(migrationsToPerform).ToNot(ContainElement(migrations.MigrationsToPerform[78]))
-				Expect(migrationsToPerform).ToNot(ContainElement(migrations.MigrationsToPerform[79]))
-			})
-		})
 	})
 
 	Context("when legacy v1 migration has already occurred", func() {
@@ -91,7 +72,7 @@ var _ = Describe("Migrations Provider", func() {
 		})
 
 		It("returns a legacy v1 migration in the list of migrations to perform", func() {
-			migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
+			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
 			Expect(err).ToNot(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V1LegacyMigrationsToPerform[0],
@@ -118,7 +99,7 @@ var _ = Describe("Migrations Provider", func() {
 		})
 
 		It("returns a legacy v2 migration in the list of migrations to perform", func() {
-			migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
+			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
 			Expect(err).ToNot(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V2LegacyMigrationsToPerform[0],
@@ -142,7 +123,7 @@ var _ = Describe("Migrations Provider", func() {
 		})
 
 		It("returns a legacy v3 migration in the list of migrations to perform", func() {
-			migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
+			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
 			Expect(err).ToNot(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V3LegacyMigrationsToPerform[0],

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrator.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrator.go
@@ -3,7 +3,6 @@ package migrations
 import (
 	"database/sql"
 	"fmt"
-	"strings"
 
 	"github.com/jmoiron/sqlx"
 	migrate "github.com/rubenv/sql-migrate"
@@ -27,7 +26,7 @@ type MigrationDb interface {
 
 //counterfeiter:generate -o fakes/migrations_provider.go --fake-name MigrationsProvider . migrationsProvider
 type migrationsProvider interface {
-	MigrationsToPerform(bool) (PolicyServerMigrations, error)
+	MigrationsToPerform() (PolicyServerMigrations, error)
 }
 
 type Migrator struct {
@@ -36,27 +35,7 @@ type Migrator struct {
 }
 
 func (m *Migrator) PerformMigrations(driverName string, migrationDb MigrationDb, maxNumMigrations int) (int, error) {
-	var mysql57 bool
-	if driverName == "mysql" {
-		row := migrationDb.QueryRow("SELECT VERSION()")
-		// if no rows are returned, we're definitely not mysql 5.7, so short circuit out
-		if row != nil {
-			var version string
-			err := row.Scan(&version)
-			if err != nil {
-				return 0, fmt.Errorf("Unable to detect MySQL Version: %s", err)
-			}
-			// mysql returns major.minor.patch version number strings
-			// e.g. `5.7.43` would be the data returned for the VERSION() query
-			mysql57 = strings.HasPrefix(version, "5.7.")
-		}
-	}
-	// at this point, the mysql57 bool is false if postgres, false if no rows were returned
-	// for SELECT VERSION(), false if the prefix doesn't start with `5.7.` (in case there's ever a 5.70)
-	// and true if 5.7.x. the above should only have thrown an error if there was a problem talking
-	// to the database to execute the query, or the row couldn't be marshalled into a string variable
-
-	migrationsToPerform, err := m.MigrationsProvider.MigrationsToPerform(mysql57)
+	migrationsToPerform, err := m.MigrationsProvider.MigrationsToPerform()
 	if err != nil {
 		return 0, fmt.Errorf("error retrieving migrations to perform: %s", err)
 	}
@@ -102,9 +81,8 @@ func (s PolicyServerMigrations) supportsDriver(driverName string) bool {
 }
 
 type PolicyServerMigration struct {
-	Id          string
-	SkipMySQL57 bool
-	Up          map[string][]string
+	Id string
+	Up map[string][]string
 }
 
 func (psm *PolicyServerMigration) forDriver(driverName string) *migrate.Migration {

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/cf-networking-helpers/db"
@@ -2006,6 +2007,9 @@ var _ = Describe("migrations", func() {
 		Describe("v82-83 - multi-value indices for security_groups space bindings", func() {
 			var spacesJson string
 			BeforeEach(func() {
+				if isPostgresOrMySQL57(realDb) {
+					Skip("skipping-unsupported-indices on non-mysql or mysql-5.7 database")
+				}
 				migrateTo("81")
 				var guids []string
 				for range 149 {
@@ -2059,7 +2063,11 @@ var _ = Describe("migrations", func() {
 		})
 
 		Describe("v86-91 - removing multi-value indices for security_groups space bindings", func() {
+
 			BeforeEach(func() {
+				if isPostgresOrMySQL57(realDb) {
+					Skip("skipping-unsupported-indices on non-mysql or mysql-5.7 database")
+				}
 				migrateTo("83")
 			})
 			Context("when v82-83 had created multi-value indices already", func() {
@@ -2311,7 +2319,7 @@ func queryTableColumnNames(tableName string, realDb *db.ConnWrapper) []string {
 }
 
 func getMigrationIndex(migrationsProvider *migrations.MigrationsProvider, migrationId string) int {
-	migrationsToPerform, err := migrationsProvider.MigrationsToPerform(false)
+	migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
 	Expect(err).NotTo(HaveOccurred())
 	for i, migration := range migrationsToPerform {
 		if migration.Id == migrationId {
@@ -2320,4 +2328,25 @@ func getMigrationIndex(migrationsProvider *migrations.MigrationsProvider, migrat
 	}
 	Fail("couldn't find migration with id: " + migrationId)
 	return -1
+}
+
+func isPostgresOrMySQL57(realDb *db.ConnWrapper) bool {
+	if realDb.DriverName() == "mysql" {
+		row := realDb.DB.QueryRow("SELECT VERSION()")
+		// if no rows are returned, we're definitely not mysql 8, so short circuit out
+		if row != nil {
+			var version string
+			err := row.Scan(&version)
+			Expect(err).NotTo(HaveOccurred())
+
+			// mysql returns major.minor.patch version number strings
+			// e.g. `5.7.43` would be the data returned for the VERSION() query
+			if strings.HasPrefix(version, "5.7.") {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+	return true
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Rolls back the SkipMysql57 logic as we don't need it and it interferedwith tests. Also only runs tests for the failed security group migrations if not postgres or mysql57, since those test cases won't work, and aren't necessary on those flavors.

Backward Compatibility
---------------
Breaking Change? no