### PR TITLE
Retry DB connections for policy-server migrations

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
@@ -107,26 +107,28 @@ func main() {
 	destination := &store.DestinationTable{}
 	policy := &store.PolicyTable{}
 
-	logger.Info("getting db connection", lager.Data{})
-	connectionPool, err := db.NewConnectionPool(
-		conf.Database,
-		conf.MaxOpenConnections,
-		conf.MaxIdleConnections,
-		time.Duration(conf.MaxConnectionsLifetimeSeconds)*time.Second,
-		logPrefix,
-		jobPrefix,
-		logger,
-	)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	logger.Info("db connection retrieved", lager.Data{})
-
+	var connectionPool *db.ConnWrapper
 	doneChan := make(chan bool, 1)
 	go func() {
 		for {
-			err := migrateAndPopulateGroupsTable(logger, conf, connectionPool)
+			logger.Info("getting db connection", lager.Data{})
+			connectionPool, err = db.NewConnectionPool(
+				conf.Database,
+				conf.MaxOpenConnections,
+				conf.MaxIdleConnections,
+				time.Duration(conf.MaxConnectionsLifetimeSeconds)*time.Second,
+				logPrefix,
+				jobPrefix,
+				logger,
+			)
+			if err != nil {
+				logger.Error("failed connecting to the database for migrations, retrying", err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			logger.Info("db connection retrieved", lager.Data{})
+
+			err = migrateAndPopulateGroupsTable(logger, conf, connectionPool)
 			if err != nil {
 				logger.Error("failed migrating and populating tags, retrying", err)
 				time.Sleep(1 * time.Second)

--- a/src/code.cloudfoundry.org/policy-server/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/integration_test.go
@@ -258,6 +258,7 @@ var _ = Describe("Integration", func() {
 				Timeout:      1,
 			}
 			conf, _, _ := helpers.DefaultTestConfig(badDbConfig, "some-address", "fixtures")
+			conf.DatabaseMigrationTimeout = 1
 			configFilePath := helpers.WriteConfigFile(conf)
 
 			policyServerCmd := exec.Command(policyServerPath, "-config-file", configFilePath)
@@ -274,7 +275,7 @@ var _ = Describe("Integration", func() {
 
 		It("should log and exit with a timeout error", func() {
 			Eventually(session, 10*time.Second).Should(gexec.Exit())
-			Expect(session.Err).To(gbytes.Say("testprefix.policy-server: db connect: unable to ping: context deadline exceeded"))
+			Eventually(session.Out).Should(gbytes.Say("db migrations and populating tags failed"))
 		})
 	})
 

--- a/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Migrate DB Binary", func() {
 			It("exits non-zero", func() {
 				conf.DatabaseMigrationTimeout = 1
 				session := helpers.RunMigrationsPreStartBinary(policyServerPath, conf)
-				Eventually(session.Wait(TimeoutShort)).Should(gexec.Exit(1))
+				Eventually(session.Wait(TimeoutShort)).Should(gexec.Exit(3))
 			})
 		})
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We moved DB migrations from a separate migrate-db command into policy-server itself. Previously migrate-db would retry DB connections until a timeout is hit, at which point it dies. Policy-server would retry *retriable* connections until a timeout was hit, and then it dies.

The integration test for migrate_db_test.go to validate that it eventually connects to a DB throws a non-retriable connection, so we needed to move the logic creating the DB connection inside the for loop, and then adjust the expectation of the tests for what errors will now be logged in this case.


Backward Compatibility
---------------
Breaking Change? no