### PR TITLE
Fix packaging spec

### DIFF
--- a/packages/policy-server/spec
+++ b/packages/policy-server/spec
@@ -35,7 +35,6 @@ files:
   - code.cloudfoundry.org/policy-server/asg_syncer/*.go # gosub
   - code.cloudfoundry.org/policy-server/cc_client/*.go # gosub
   - code.cloudfoundry.org/policy-server/cleaner/*.go # gosub
-  - code.cloudfoundry.org/policy-server/cmd/migrate-db/*.go # gosub
   - code.cloudfoundry.org/policy-server/cmd/policy-server/*.go # gosub
   - code.cloudfoundry.org/policy-server/cmd/policy-server-asg-syncer/*.go # gosub
   - code.cloudfoundry.org/policy-server/cmd/policy-server-internal/*.go # gosub


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
These got re-added when trying to make the linter job happy, when the linter should have been updated to not contain references to migrate-db.


Backward Compatibility
---------------
Breaking Change? no