### PR TITLE
Fix broken comments in Dynamic ASGs docs

### DIFF
--- a/docs/04-a-dynamic-asgs.md
+++ b/docs/04-a-dynamic-asgs.md
@@ -25,7 +25,7 @@ tags: [cf-networking-release]
     * [Q&A:](#qa)
 
 <!-- vim-markdown-toc -->
-# Dynamic ASGs 
+# Dynamic ASGs
 
 ## Overview
 
@@ -48,7 +48,7 @@ these changes to take effect immediately with no extra action on their part.
 
 ![non-dynamic ASG architecture
 diagram](asg-enforcement-during-container-create-architecture.png)
-<!-- Use exiftool and check Url metadata for PNG to see where this PNG came from --!>
+<!-- Use exiftool and check Url metadata for PNG to see where this PNG came from -->
 
 **Steps taken to create and enforce ASGs**
 1. An operator creates and binds and ASG.
@@ -67,13 +67,13 @@ rules will be automatically enforced.
 
 ![dynamic ASG architecture
 diagram](dynamic-asg-enforcement-architecture.png)
-<!-- Use exiftool and check Url metadata for PNG to see where this PNG came from --!>
+<!-- Use exiftool and check Url metadata for PNG to see where this PNG came from -->
 
 **Steps taken to create and enforce dynamic ASGs**
 1. An operator creates and binds and ASG.
 1. Cloud Controller updates its internal reference to the last time ASGs were modified. **NOTE** This only occurs on `/v3` API endpoints.
 1. A new job, the Policy Server ASG Syncer, polls Cloud Controller for the last time ASGs were updated. If changes have been made, it syncs all ASGs.
-   The syncer saves all the ASGs in the policy server DB.  This poll interval is
+   The syncer saves all the ASGs in the policy server DB. This poll interval is
    controlled by the syncer's bosh property
    [`asg_poll_interval_seconds`](https://github.com/cloudfoundry/cf-networking-release/blob/0c5029c88e9f61bb94829b4e0b8ed6732f30f9f0/jobs/policy-server-asg-syncer/spec#L31-L33).
 1. The vxlan policy agent (VPA) polls the policy server for c2c policies _and_
@@ -157,8 +157,8 @@ Given that we support multi-tenant systems, a malicious actor could do this to b
 
 Solution introduced in `policy-server's` [cc_client.GetSecurityGroups() method](https://github.com/cloudfoundry/cf-networking-release/blob/develop/src/code.cloudfoundry.org/policy-server/cc_client/client.go#L372).
 
+### Solution Illustration (bolded pages are the ones we actually query capi for):
 
-###  Solution Illustration (bolded pages are the ones we actually query capi for):
 First Query (page=1, page_size=5000):<br>
 **page1: 0-4999**, page2: 5000-9999, page3: 10000-14999, page4: 15000-19999<br><br>
 Second Query (page=2, page_size=4999):<br>
@@ -166,7 +166,7 @@ page1: 0-4998, **page2: 4999-9997**, page3: 9998-14996, page4: 14997 - 19995, pa
 Third Query (page=3, page_size=4998):<br>
 page1: 0-4997, page2: 4998-9995, **page3: 9996-14993**, page4: 14994 - 19991, page5: 19992 - 19999<br><br>
 Fourth Query ([age=4, page_size=4997):<br>
-page1: 0-4996, page2: 4997-9993,  page3: 9994 - 14990, **page4: 14991 - 19987**, page5: 19988 - 19999<br><br>
+page1: 0-4996, page2: 4997-9993, page3: 9994 - 14990, **page4: 14991 - 19987**, page5: 19988 - 19999<br><br>
 Fifth Query (page=5, page_size=4996):<br>
 page1: 0-4995, page2: 4996 - 9991, page3: 9992 - 14987, page4: 14988 - 19983, **page5: 19984 - 19999**<br><br>
 
@@ -175,8 +175,7 @@ On the third query we check that index1 of the third query (9997) was the same a
 On the fourth query, we check that index2 of the fourth query (14993) was the same as the last index of the third query (14993).<br>
 On the fifth query, we check that index3 of the fifth query (19987) was the same as the last index of the fourth query (19987).<br>
 
-
-###  Q&A:
+### Q&A:
 
 Q: Why is this complex pagination necessary?<br>
 A: We need to detect any changes (deletions) in the capi response that happened after the start of the poll cycle. We sort by `created_by`, so any additions are at the end. However deletions are likely somewhere in the middle and cause all ASGs following them to be shifted up, causing us to miss non-deleted ASGs (see "Guard against the following scenario, above).
@@ -191,7 +190,7 @@ Q: Why do we have to increment the index of the ASG we are inspecting?<br>
 A: As we decrement, the overlap we create will get bigger and bigger. We don't need to compare all the contents of the overlap, just the last overlapping ASG (see Solution Illustration, above).
 
 Q: What happens when there are +5000 pages?<br>
-A: Actualy, once there are *2500* pages, we run out of space in the result set. (This is because page size goes DOWN at the same time that index goes UP). This would be a problem; however even our customers with the largest numbers of ASGs don't have 2500 pages of 5000+4999+4998...	ASGs per page.
+A: Actualy, once there are *2500* pages, we run out of space in the result set. (This is because page size goes DOWN at the same time that index goes UP). This would be a problem; however even our customers with the largest numbers of ASGs don't have 2500 pages of 5000+4999+4998... ASGs per page.
 
 Q: How long will this algorithm be in place?<br>
 A: Our first priority for TAS 2.14 is to refactor ASGs so that policy-server, not capi, is the source of truth for ASGs. This will remove this feature's dependcy on capi and we will be able to remove this algorithm.


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

The Dynamic ASGs article [rendering](https://github.com/cloudfoundry/cf-networking-release/blob/develop/docs/04-a-dynamic-asgs.md) is currently broken due to missing closing comments. [Preview](https://github.com/sap-contributions/cf-networking-release/blob/e92f72ba1b7aa21ac23d51200a76d8baf36d0e51/docs/04-a-dynamic-asgs.md) of the new article.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
