### PR TITLE
[RFC0038] External Networker IPv6 support

### DIFF
--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager.go
@@ -54,6 +54,7 @@ type UpInputs struct {
 type UpOutputs struct {
 	Properties struct {
 		ContainerIP      string `json:"garden.network.container-ip"`
+		ContainerIPv6    string `json:"garden.network.container-ipv6,omitempty"`
 		DeprecatedHostIP string `json:"garden.network.host-ip"`
 		MappedPorts      string `json:"garden.network.mapped-ports"`
 		Interface        string `json:"garden.network.interface,omitempty"`
@@ -124,11 +125,12 @@ func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error
 
 	assertedResult := result040.(*types040.Result)
 
-	var containerIP *types040.IPConfig
+	var containerIP, containerIPv6 *types040.IPConfig
 	for _, ip := range assertedResult.IPs {
 		if ip.Version == "4" {
 			containerIP = ip
-			break
+		} else if ip.Version == "6" {
+			containerIPv6 = ip
 		}
 	}
 
@@ -152,6 +154,11 @@ func (m *Manager) Up(containerHandle string, inputs UpInputs) (*UpOutputs, error
 	outputs.Properties.DeprecatedHostIP = "255.255.255.255"
 	outputs.DNSServers = assertedResult.DNS.Nameservers
 	outputs.SearchDomains = m.SearchDomains
+
+	if containerIPv6 != nil {
+		outputs.Properties.ContainerIPv6 = containerIPv6.Address.IP.String()
+	}
+
 	return &outputs, nil
 }
 

--- a/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/manager/manager_test.go
@@ -376,6 +376,25 @@ var _ = Describe("Manager", func() {
 				Expect(err).To(MatchError("proxy redirect apply: bang"))
 			})
 		})
+
+		Context("when there is an IPv6 address in the CNI result", func() {
+			BeforeEach(func() {
+				cniUpResult.IPs = append(cniUpResult.IPs, &types040.IPConfig{
+					Version: "6",
+					Address: net.IPNet{
+						IP:   net.ParseIP("2001:db8::68"),
+						Mask: net.CIDRMask(64, 128),
+					},
+				})
+			})
+
+			It("should return the IPv6 address in the CNI result as a property", func() {
+				out, err := mgr.Up(containerHandle, upInputs)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(out.Properties.ContainerIPv6).To(Equal("2001:db8::68"))
+			})
+		})
 	})
 
 	Describe("Down", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[RFC0038](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0038-ipv6-dual-stack-for-cf.md)
[Tracking Issue](https://github.com/cloudfoundry/community/issues/1107)

IPv6 address is returned by the CNI plugins when using the external networker.
This change ensures that it is properly propagated to other components in the chain(guardian, executor)


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
