### PR TITLE
modify outbound conn limit test to use nginx app

### DIFF
--- a/src/code.cloudfoundry.org/test/acceptance/outbound_conn_limit_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/outbound_conn_limit_test.go
@@ -30,7 +30,7 @@ var (
 
 var _ = Describe("Outbound connection limit", func() {
 	BeforeEach(func() {
-		proxyName = testConfig.Prefix + "-proxy"
+		proxyName = testConfig.Prefix + "-nginx"
 		spammerName = testConfig.Prefix + "-spammer"
 		if !testConfig.RunExperimentalOutboundConnLimitTest {
 			Skip("Skipping outbound connection limit test")
@@ -54,8 +54,8 @@ var _ = Describe("Outbound connection limit", func() {
 			app_helpers.AppReport(proxyName)
 		})
 		It("the connections get rate limited", func() {
-			By("pushing proxy")
-			pushProxy(proxyName)
+			By("pushing nginx proxy")
+			pushNginx(proxyName)
 
 			By("pushing spammer")
 			pushSpammer(spammerName)
@@ -81,6 +81,14 @@ func pushSpammer(spammerName string) {
 
 	session = cf.Cf("start", spammerName)
 	Expect(session.Wait(Timeout_Push)).To(gexec.Exit(0))
+}
+
+func pushNginx(appName string) {
+	Expect(cf.Cf(
+		"push", appName,
+		"-p", appDir("nginx"),
+		"-f", defaultManifest("nginx"),
+	).Wait(Timeout_Push)).To(gexec.Exit(0))
 }
 
 func spam() *spamAPI.SpamResp {

--- a/src/example-apps/nginx/manifest.yml
+++ b/src/example-apps/nginx/manifest.yml
@@ -1,0 +1,8 @@
+applications:
+- name: my-nginx-app
+  memory: 64M
+  instances: 1
+  buildpacks:
+    - nginx_buildpack
+  path: .
+

--- a/src/example-apps/nginx/nginx.conf
+++ b/src/example-apps/nginx/nginx.conf
@@ -1,0 +1,13 @@
+events {
+   worker_connections  1024;
+}
+
+http {
+   server {
+       listen {{port}};
+
+       location = / {
+            return 200 "Hello NGINX!";
+       }
+   }
+}


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
modify outbound conn limit test to use nginx app instead of proxy app to avoid clash with outbound limits. Also proxy app is heavily used in other tests.
```
➜  acceptance git:(spam-nginx-app) ✗ go test -v .
=== RUN   TestAcceptance
Running Suite: Acceptance Suite - /Users/karthickudayakumar/Documents/git/cloudfoundry/cf-networking-release/src/code.cloudfoundry.org/test/acceptance
======================================================================================================================================================
Random Seed: 1754944252

Will run 1 of 1 specs
API endpoint: https://api.sys.tas.6d3c76d9.shepherd.tanzu.broadcom.net


Authenticating...
OK

Select an org:
1. system
2. test1

Org (enter to skip): API endpoint:   https://api.sys.tas.6d3c76d9.shepherd.tanzu.broadcom.net
API version:    3.185.0
user:           admin
No org or space targeted, use 'cf target -o ORG -s SPACE'
API endpoint: https://api.sys.tas.6d3c76d9.shepherd.tanzu.broadcom.net


Authenticating...
OK

Select an org:
1. system
2. test1

Org (enter to skip): API endpoint:   https://api.sys.tas.6d3c76d9.shepherd.tanzu.broadcom.net
API version:    3.185.0
user:           admin
No org or space targeted, use 'cf target -o ORG -s SPACE'
•

Ran 1 of 1 Specs in 70.616 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAcceptance (70.62s)
PASS
ok      code.cloudfoundry.org/test/acceptance   70.835s`
```

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
