### PR TITLE
Update migrations 97 and 98 to be more tolerant of environments where  spaces have somehow been bound multiple times to security groups

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
@@ -2208,6 +2208,59 @@ var _ = Describe("migrations", func() {
 					migrateTo("100")
 				})
 			})
+			Context("when a security group has duplicated staging spaces", func() {
+				BeforeEach(func() {
+					_, err := realDb.Exec(`INSERT INTO security_groups (name, guid, staging_spaces, running_spaces) VALUES
+						('guid-1', 'guid-1', JSON_ARRAY('space-1', 'space-1', 'space-2'), JSON_ARRAY()),
+						('guid-2', 'guid-2', JSON_ARRAY('space-1', 'space-2'), JSON_ARRAY())
+						`)
+					Expect(err).NotTo(HaveOccurred())
+				})
+				It("migrates without error and populates the join table", func() {
+					migrateTo("100")
+					ExpectAssociatedSpacesToConsistOf(realDb, "staging", []JoinRow{{
+						SecurityGroup: "guid-1",
+						Space:         "space-1",
+					}, {
+						SecurityGroup: "guid-1",
+						Space:         "space-2",
+					}, {
+						SecurityGroup: "guid-2",
+						Space:         "space-1",
+					}, {
+						SecurityGroup: "guid-2",
+						Space:         "space-2",
+					}})
+					ExpectAssociatedSpacesToConsistOf(realDb, "running", []JoinRow{})
+				})
+			})
+			Context("when a security group has duplicated running spaces", func() {
+				BeforeEach(func() {
+					_, err := realDb.Exec(`INSERT INTO security_groups (name, guid, staging_spaces, running_spaces) VALUES
+						('guid-1', 'guid-1', JSON_ARRAY(), JSON_ARRAY('space-1', 'space-1', 'space-2')),
+						('guid-2', 'guid-2', JSON_ARRAY(), JSON_ARRAY('space-1', 'space-2'))
+					`)
+					Expect(err).NotTo(HaveOccurred())
+				})
+				It("migrates without error and populates the join table", func() {
+					migrateTo("100")
+
+					ExpectAssociatedSpacesToConsistOf(realDb, "running", []JoinRow{{
+						SecurityGroup: "guid-1",
+						Space:         "space-1",
+					}, {
+						SecurityGroup: "guid-1",
+						Space:         "space-2",
+					}, {
+						SecurityGroup: "guid-2",
+						Space:         "space-1",
+					}, {
+						SecurityGroup: "guid-2",
+						Space:         "space-2",
+					}})
+					ExpectAssociatedSpacesToConsistOf(realDb, "staging", []JoinRow{})
+				})
+			})
 			Context("when a security group has running spaces but no staging spaces", func() {
 				BeforeEach(func() {
 					_, err := realDb.Exec(

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0097.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0097.go
@@ -9,12 +9,12 @@ var migration_v0097 = map[string][]string{
 			security_groups
 		JOIN 
 			(SELECT id from temp_sequence) x
-		WHERE x.id < JSON_LENGTH(security_groups.running_spaces)`,
+		WHERE x.id < JSON_LENGTH(security_groups.running_spaces) ON DUPLICATE KEY UPDATE space_guid = VALUES(space_guid), security_group_guid = VALUES(security_group_guid)`,
 	},
 	"postgres": {
 		`INSERT INTO running_security_groups_spaces (security_group_guid, space_guid) SELECT
 			guid AS security_group_guid,
 			jsonb_array_elements_text(running_spaces) AS space_id
-		FROM security_groups`,
+		FROM security_groups ON CONFLICT (security_group_guid, space_guid) DO NOTHING`,
 	},
 }

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0098.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0098.go
@@ -9,12 +9,12 @@ var migration_v0098 = map[string][]string{
 			security_groups
 		JOIN 
 			(SELECT id from temp_sequence) x
-		WHERE x.id < JSON_LENGTH(security_groups.staging_spaces)`,
+		WHERE x.id < JSON_LENGTH(security_groups.staging_spaces) ON DUPLICATE KEY UPDATE space_guid = VALUES(space_guid), security_group_guid = VALUES(security_group_guid)`,
 	},
 	"postgres": {
 		`INSERT INTO staging_security_groups_spaces (security_group_guid, space_guid) SELECT
 			guid AS security_group_guid,
 			jsonb_array_elements_text(staging_spaces) AS space_id
-		FROM security_groups`,
+		FROM security_groups ON CONFLICT (security_group_guid, space_guid) DO NOTHING`,
 	},
 }


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Addreses #347. Not an issue to modify these migrations because it's allowing broken ones to succeed, and won't change if successful ones ran or not.

Backward Compatibility
---------------
Breaking Change? no