### PR TITLE
remove the check for bosh-dns wait file

### DIFF
--- a/jobs/policy-server/templates/pre-start.erb
+++ b/jobs/policy-server/templates/pre-start.erb
@@ -1,11 +1,6 @@
 #!/bin/bash -exu
 
 <% if spec.bootstrap %>
-
-# can remove this check once bosh-dns is in cf-deployment :)
-if [ -f /var/vcap/jobs/bosh-dns/bin/wait ]; then
     # ensure bosh-dns is up and running
     /var/vcap/jobs/bosh-dns/bin/wait
-fi
-
 <% end %>


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Removing the check for `/var/vcap/jobs/bosh_dns/bin/wait` if it exists.  This binary presents in bosh-dns.
https://github.com/cloudfoundry/bosh-dns-release/blob/master/jobs/bosh-dns/templates/wait.erb


```
~/workspace/cf-networking-release |TNZ-44273 ✔| 
$ ./scripts/test-in-docker.bash policy-server
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:69bf91c0f6c39944f6ad791d6dc27292f9d3180a62e29c57d392724b7dd22557
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
Error response from daemon: No such container: cf-networking-release-mysql-docker-container
271abe539d883ff3c9a7c6bb454ad5c50864958933e6ace3f8a0d9aca0b67f70
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Bundler 2.7.2 is running, but your lockfile was generated with 2.5.23. Installing Bundler 2.5.23 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.5.23
Installing bundler 2.5.23
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/.........
Fetching ast 2.4.2
Fetching backport 1.2.0
Installing backport 1.2.0
Installing ast 2.4.2
Fetching base64 0.1.1
Fetching benchmark 0.2.1
Installing base64 0.1.1
Installing benchmark 0.2.1
Fetching semi_semantic 1.2.0
Installing semi_semantic 1.2.0
Fetching e2mmap 0.1.0
Fetching diff-lcs 1.5.1
Installing e2mmap 0.1.0
Installing diff-lcs 1.5.1
Fetching jaro_winkler 1.5.6
Installing jaro_winkler 1.5.6 with native extensions
Fetching json 2.6.3
Installing json 2.6.3 with native extensions
Fetching rexml 3.3.9
Installing rexml 3.3.9
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching racc 1.7.3
Installing racc 1.7.3 with native extensions
Fetching parallel 1.23.0
Installing parallel 1.23.0
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching rbs 2.8.4
Installing rbs 2.8.4 with native extensions
Fetching regexp_parser 2.8.2
Installing regexp_parser 2.8.2
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Fetching unicode-display_width 2.5.0
Installing unicode-display_width 2.5.0
Fetching thor 1.2.2
Installing ruby-progressbar 1.13.0
Fetching tilt 2.3.0
Installing thor 1.2.2
Installing tilt 2.3.0
Fetching yard 0.9.36
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching kramdown 2.4.0
Installing kramdown 2.4.0
Installing yard 0.9.36
Fetching nokogiri 1.16.5 (x86_64-linux)
Fetching parser 3.2.2.4
Installing parser 3.2.2.4
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Installing nokogiri 1.16.5 (x86_64-linux)
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching kramdown-parser-gfm 1.1.0
Installing kramdown-parser-gfm 1.1.0
Fetching rubocop-ast 1.29.0
Installing rubocop-ast 1.29.0
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.57.1
Fetching reverse_markdown 2.1.1
Installing reverse_markdown 2.1.1
Installing rubocop 1.57.1
Fetching solargraph 0.49.0
Installing solargraph 0.49.0
Bundle complete! 4 Gemfile dependencies, 36 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
..................................................................

Finished in 0.26958 seconds (files took 0.15995 seconds to load)
66 examples, 0 failures
```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
