### PR TITLE
Update all Golang example apps to use the latest available version

### DIFF
--- a/src/example-apps/proxy/manifest.yml
+++ b/src/example-apps/proxy/manifest.yml
@@ -6,4 +6,4 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: proxy
-      GOVERSION: go1.23
+      GOVERSION: latest

--- a/src/example-apps/raw-response/manifest.yml
+++ b/src/example-apps/raw-response/manifest.yml
@@ -6,4 +6,4 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: raw-response
-      GOVERSION: go1.23
+      GOVERSION: latest

--- a/src/example-apps/registry/manifest.yml
+++ b/src/example-apps/registry/manifest.yml
@@ -7,4 +7,4 @@ applications:
     instances: 1
     env:
       GOPACKAGENAME: registry
-      GOVERSION: go1.23
+      GOVERSION: latest

--- a/src/example-apps/smoke/manifest.yml
+++ b/src/example-apps/smoke/manifest.yml
@@ -6,5 +6,5 @@ applications:
     buildpacks: [go_buildpack]
     env:
       GOPACKAGENAME: smoke
-      GOVERSION: go1.23
+      GOVERSION: latest
       PROXY_APP_URL: http://proxy.some-cf-deployment.example.com

--- a/src/example-apps/spammer/manifest.yml
+++ b/src/example-apps/spammer/manifest.yml
@@ -6,4 +6,4 @@ applications:
   buildpacks: [go_buildpack]
   env:
     GOPACKAGENAME: example-apps/spammer
-    GOVERSION: go1.23
+    GOVERSION: latest

--- a/src/example-apps/tick/manifest.yml
+++ b/src/example-apps/tick/manifest.yml
@@ -7,7 +7,7 @@ applications:
     instances: 3
     env:
       GOPACKAGENAME: tick
-      GOVERSION: go1.23
+      GOVERSION: latest
       REGISTRY_BASE_URL: http://registry.some-cf-deployment.example.com
       START_PORT: 7000
       LISTEN_PORTS: 3


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

This PR updates the `GOVERSION` env var in the manifest.yml for each Golang
example app to "latest" to instruct the Golang buildpack to use the latest
available version of Golang when deploying the app. This will help to avoid
needing to update the manifests whenever a version of Golang goes out of
support.

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
