### PR TITLE
remove deprecated cni loader method to read conf files

### DIFF
--- a/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"io"
-	"time"
 
 	"github.com/containernetworking/cni/libcni"
 )
@@ -24,10 +24,7 @@ func (l *CNILoader) GetCNIConfig() *libcni.CNIConfig {
 
 func (l *CNILoader) GetNetworkConfig() (*libcni.NetworkConfigList, error) {
 
-	var (
-		confFilePaths     []string
-		confListFilePaths []string
-	)
+	var confListFilePaths []string
 
 	err := filepath.Walk(l.ConfigDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -38,9 +35,7 @@ func (l *CNILoader) GetNetworkConfig() (*libcni.NetworkConfigList, error) {
 			return nil
 		}
 
-		if strings.HasSuffix(path, ".conf") {
-			confFilePaths = append(confFilePaths, path)
-		} else if strings.HasSuffix(path, ".conflist") {
+		if strings.HasSuffix(path, ".conflist") {
 			confListFilePaths = append(confListFilePaths, path)
 		}
 
@@ -48,7 +43,7 @@ func (l *CNILoader) GetNetworkConfig() (*libcni.NetworkConfigList, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("error loading config: %s", err)
+		return nil, fmt.Errorf("error walking config directory: %s", err)
 	}
 
 	var toReturn *libcni.NetworkConfigList
@@ -61,27 +56,10 @@ func (l *CNILoader) GetNetworkConfig() (*libcni.NetworkConfigList, error) {
 		}
 
 		toReturn = confList
-	} else if len(confFilePaths) > 0 {
-		path := confFilePaths[0]
-		//lint:ignore SA1019 - we will address this, but would like to keep units passing
-		conf, err := libcni.ConfFromFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("unable to load config from %s: %s", path, err)
-		}
-
-		//lint:ignore SA1019 - we will address this, but would like to keep units passing
-		confList, err := libcni.ConfListFromConf(conf)
-		if err != nil {
-			// untested, unable to cause failure case.
-			return nil, fmt.Errorf("unable to upconvert from conf to conf list %s: %s", path, err)
-		}
-
-		toReturn = confList
 	}
 
-	if (len(confListFilePaths) + len(confFilePaths)) > 1 {
-		fmt.Fprintf(l.Logger, `%s - Only one CNI config file or conflist (chain) will be executed. 
-							If a conf and conflist file are both present, then the conflist will be executed. 
+	if len(confListFilePaths) > 1 {
+		fmt.Fprintf(l.Logger, `%s - Only one CNI conflist (chain) will be executed.
 							If multiple CNI config files are present, behavior is undefined.`, time.Now().Format(time.RFC3339))
 	}
 

--- a/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/cni/cni_loader_test.go
@@ -50,7 +50,7 @@ var _ = Describe("GetNetworkConfig", func() {
 
 		It("returns a meaningful error", func() {
 			_, err := cniLoader.GetNetworkConfig()
-			Expect(err).To(MatchError(HavePrefix("error loading config:")))
+			Expect(err).To(MatchError(HavePrefix("error walking config directory:")))
 		})
 	})
 
@@ -59,21 +59,6 @@ var _ = Describe("GetNetworkConfig", func() {
 			netListCfgs, err := cniLoader.GetNetworkConfig()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(netListCfgs).To(BeNil())
-		})
-	})
-
-	Context("when a valid config file exists", func() {
-		BeforeEach(func() {
-			err = os.WriteFile(filepath.Join(dir, "foo.conf"), []byte(`{ "name": "mynet", "type": "bridge" }`), 0600)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("loads a single network config", func() {
-			netListCfg, err := cniLoader.GetNetworkConfig()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(netListCfg.Name).To(Equal("mynet"))
-			Expect(netListCfg.Plugins).To(HaveLen(1))
-			Expect(*netListCfg.Plugins[0].Network).To(Equal(*expectedBridgeNetwork))
 		})
 	})
 
@@ -101,11 +86,6 @@ var _ = Describe("GetNetworkConfig", func() {
 
 	Context("when multiple valid config and config list files exists", func() {
 		BeforeEach(func() {
-			err = os.WriteFile(filepath.Join(dir, "aaa.conf"), []byte(`{ "name": "mynet", "type": "bridge" }`), 0600)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = os.WriteFile(filepath.Join(dir, "zzz.conf"), []byte(`{ "name": "barnet", "type": "dummy" }`), 0600)
-			Expect(err).NotTo(HaveOccurred())
 
 			err = os.WriteFile(filepath.Join(dir, "ccc.conflist"), []byte(`{ "name": "nopelist", "plugins": [{ "name": "badnet", "type": "bridge" }] }`), 0600)
 			Expect(err).NotTo(HaveOccurred())
@@ -125,7 +105,7 @@ var _ = Describe("GetNetworkConfig", func() {
 		It("logs warning for the skipped files", func() {
 			_, err := cniLoader.GetNetworkConfig()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logger.String()).To(ContainSubstring("Only one CNI config file or conflist (chain) will be executed"))
+			Expect(logger.String()).To(ContainSubstring("Only one CNI conflist (chain) will be executed"))
 		})
 	})
 })

--- a/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
@@ -92,9 +92,10 @@ func writeConfig(index int, outDir string) error {
 	{
 		"cniVersion": "0.4.0",
 		"name": "some-net-%d",
-		"type": "plugin-%d"
+		"type": "plugin-%d",
+		"plugins": [{"type": "plugin-0"}]
 	}`, index, index)
-	outpath := filepath.Join(outDir, fmt.Sprintf("%d-plugin-%d.conf", 10*index, index))
+	outpath := filepath.Join(outDir, fmt.Sprintf("%d-plugin-%d.conflist", 10*index, index))
 	return os.WriteFile(outpath, []byte(config), 0600)
 }
 


### PR DESCRIPTION
This reverts commit 43eb98aae115625183cfd1fd207fff58bbe3839a.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
NCP updated the cni conf list and this commit is reapplied.

Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
