### PR TITLE
asy syncer - preserve the sglist error type

### DIFF
--- a/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer.go
+++ b/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer.go
@@ -4,6 +4,7 @@ package asg_syncer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -98,9 +99,10 @@ func (a *ASGSyncer) Poll() error {
 	retrieveStartTime := a.Clock.Now()
 	ccSGs, err := a.CCClient.GetSecurityGroups(token)
 	if err != nil {
-		if _, ok := err.(cc_client.UnstableSecurityGroupListError); ok {
+		var unstableErr cc_client.UnstableSecurityGroupListError
+		if errors.As(err, &unstableErr) {
 			if a.Clock.Now().After(a.lastSyncTime.Add(a.RetryDeadline)) {
-				return fmt.Errorf("unable to retrieve a consistent listing of security groups from CAPI after '%s': %s", a.RetryDeadline, err)
+				return fmt.Errorf("unable to retrieve a consistent listing of security groups from CAPI after '%s': %s", a.RetryDeadline, unstableErr)
 			}
 			return nil
 		}

--- a/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
+++ b/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
@@ -340,7 +340,9 @@ var _ = Describe("ASGSyncer", func() {
 				})
 				Context("if changes are detected during capi pagination", func() {
 					BeforeEach(func() {
-						fakeCCClient.GetSecurityGroupsReturns([]cc_client.SecurityGroupResource{}, error(cc_client.NewUnstableSecurityGroupListError(fmt.Errorf("unstable list"))))
+						innerErr := cc_client.NewUnstableSecurityGroupListError(fmt.Errorf("unstable list"))
+						wrappedErr := fmt.Errorf("Ran out of retry attempts: %w", innerErr)
+						fakeCCClient.GetSecurityGroupsReturns([]cc_client.SecurityGroupResource{}, wrappedErr)
 					})
 					It("doesn't return an error", func() {
 						err := asgSyncer.Poll()

--- a/src/code.cloudfoundry.org/policy-server/cc_client/client.go
+++ b/src/code.cloudfoundry.org/policy-server/cc_client/client.go
@@ -463,9 +463,8 @@ func (c *Client) GetSecurityGroups(token string) ([]SecurityGroupResource, error
 	}
 
 	if err != nil {
-		return []SecurityGroupResource{}, fmt.Errorf("Ran out of retry attempts. Last error was: %s\n", err.Error())
+		return []SecurityGroupResource{}, fmt.Errorf("Ran out of retry attempts. Last error was: %w", err)
 	}
-
 	return securityGroups, nil
 }
 


### PR DESCRIPTION
ai-assisted=yes
TNZ-86372

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Preserve the error type for unstable asg list. 
Return the UnstableSecurityGroupListError type error instead of a string value. In frequent security group list update scenarios, the error condition check always failed and crashed the asg_syncer process. By checking the correct type, the asg_syncer process can now retry until the RetryDeadline is over.

Test results:
```
~/workspace/cf-networking-release |asg-sync-issue ✔| 
$ ./scripts/create-docker-container.bash 
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:33f5fc1519bd5e02da519a2667f7ed94e7e3ebc8a029a6b2786f332906e07926
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
Error response from daemon: No such container: cf-networking-release-mysql-docker-container
root@8e26fc8a4b51:/# ./repo/scripts/docker/test.bash policy-server
Verifying: verify_go repo/src/code.cloudfoundry.org/policy-server
go version go1.26.1 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/policy-server
Verifying: verify_govet repo/src/code.cloudfoundry.org/policy-server
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/policy-server
booting mysql................connection established to mysql
booting mysqlconnection established to mysql
Will skip:
  ./integration
  ./integration/timeouts
  ./store
  ./store/migrations
[1773676030] Api Suite - 26/26 specs - 7 procs •••••••••••••••••••••••••• SUCCESS! 161.756826ms 
[1773676030] ApiV0 Suite - 17/17 specs - 7 procs ••••••••••••••••• SUCCESS! 69.537051ms 
[1773676030] ApiV0Internal Suite - 8/8 specs - 7 procs •••••••• SUCCESS! 126.558274ms 
[1773676030] ASG Syncer Suite - 19/19 specs - 7 procs ••••••••••••••••••• SUCCESS! 1.055609654s 
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
