### PR TITLE
Standardize tests to use NotTo instead of ToNot

### DIFF
--- a/src/code.cloudfoundry.org/bosh-dns-adapter/config/config_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/config/config_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Config", func() {
 				"log_level_port": 9090
 			}`)
 			parsedConfig, err = NewConfig(configJSON)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("contains the values in the JSON", func() {

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/handlers/get_ip_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/handlers/get_ip_test.go
@@ -160,7 +160,7 @@ var _ = Describe("GetIP", func() {
 	Context("when requesting anything but an A record", func() {
 		It("should return a successful response with no answers", func() {
 			request, err := http.NewRequest("GET", "?type=16&name=app-id.internal.local.", nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			getIP.ServeHTTP(resp, request)
 

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/main_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/main_test.go
@@ -104,13 +104,13 @@ var _ = Describe("Main", func() {
 		)
 
 		tempConfigFile, err = os.CreateTemp(os.TempDir(), "sd")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		_, err = tempConfigFile.Write([]byte(configFileContents))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		startCmd := exec.Command(pathToServer, "-c", tempConfigFile.Name())
 		session, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -227,7 +227,7 @@ var _ = Describe("Main", func() {
 			startCmd := exec.Command(pathToServer, "-c", tempConfigFile.Name())
 			var err error
 			session2, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -338,7 +338,7 @@ var _ = Describe("Main", func() {
 			startCmd := exec.Command(pathToServer, "-c", "/non-existent-path")
 			var err error
 			session2, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -370,7 +370,7 @@ var _ = Describe("Main", func() {
 			startCmd := exec.Command(pathToServer)
 			var err error
 			session2, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -387,15 +387,15 @@ var _ = Describe("Main", func() {
 			Eventually(session).Should(gbytes.Say("bosh-dns-adapter.server-started"))
 			url := fmt.Sprintf("http://127.0.0.1:%s?type=16&name=app-id.internal.local.", dnsAdapterPort)
 			request, err := http.NewRequest("GET", url, nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			resp, err := http.DefaultClient.Do(request)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			all, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(all)).To(MatchJSON(`{
 					"Status": 0,
@@ -560,12 +560,12 @@ var _ = Describe("Main", func() {
 		It("logs at info level by default", func() {
 			url := fmt.Sprintf("http://127.0.0.1:%s?type=1&name=app-id.internal.local.", dnsAdapterPort)
 			request, err := http.NewRequest("GET", url, nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			resp, err := http.DefaultClient.Do(request)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200))
 
-			Expect(session).ToNot(gbytes.Say("bosh-dns-adapter.serve-request"))
+			Expect(session).NotTo(gbytes.Say("bosh-dns-adapter.serve-request"))
 		})
 
 		It("logs at debug level when configured", func() {
@@ -573,9 +573,9 @@ var _ = Describe("Main", func() {
 
 			url := fmt.Sprintf("http://127.0.0.1:%s?type=1&name=app-id.internal.local.", dnsAdapterPort)
 			request, err := http.NewRequest("GET", url, nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			resp, err := http.DefaultClient.Do(request)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(200))
 
 			Eventually(session).Should(gbytes.Say("bosh-dns-adapter.serve-request"))
@@ -588,15 +588,15 @@ func requestLogChange(logLevel string, port int) *http.Response {
 	postBody := strings.NewReader(logLevel)
 	url := fmt.Sprintf("http://localhost:%d/log-level", port)
 	response, err := client.Post(url, "text/plain", postBody)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	return response
 }
 
 func makeDNSRequest(url string, expectedResponseCode int) {
 	request, err := http.NewRequest("GET", url, nil)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	resp, err := http.DefaultClient.Do(request)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(expectedResponseCode))
 }
 

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/sdcclient/service_discovery_client_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/sdcclient/service_discovery_client_test.go
@@ -126,7 +126,7 @@ var _ = Describe("ServiceDiscoveryClient", func() {
 
 			It("returns the ips in the server response", func() {
 				actualIPs, err := client.IPs("app-id.apps.internal.")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualIPs).To(ConsistOf("192.168.0.1", "192.168.0.2"))
 			})
@@ -168,14 +168,14 @@ var _ = Describe("ServiceDiscoveryClient", func() {
 							}],
 							"service": ""
 						}`))
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 
 			It("shuffles them to return them in random order", func() {
 				Eventually(func() []string {
 					ips, err := client.IPs("app-id.apps.internal.")
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					return ips
 				}).Should(Equal([]string{"192.168.0.3", "192.168.0.1", "192.168.0.2"}))
 			})
@@ -238,7 +238,7 @@ var _ = Describe("ServiceDiscoveryClient", func() {
 			It("retries and returns the successful response", func() {
 				startTime := time.Now()
 				actualIPs, err := client.IPs("app-id.apps.internal.")
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualIPs).To(ConsistOf("192.168.0.1", "192.168.0.2"))
 

--- a/src/code.cloudfoundry.org/bosh-dns-adapter/vip/provider_test.go
+++ b/src/code.cloudfoundry.org/bosh-dns-adapter/vip/provider_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Provider", func() {
 	})
 
 	It("returns a parsable IP", func() {
-		Expect(net.ParseIP(provider.Get("a-hostname.apps.internal"))).ToNot(BeNil())
+		Expect(net.ParseIP(provider.Get("a-hostname.apps.internal"))).NotTo(BeNil())
 	})
 
 	Specify("the same hostname always returns the same VIP", func() {

--- a/src/code.cloudfoundry.org/garden-external-networker/integration/error_handling_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/integration/error_handling_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Garden External Networker errors", func() {
 		Expect(configFile.Close()).To(Succeed())
 
 		dir, err := os.MkdirTemp("", "fake-cni-dir")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		stateFilePath, err := os.CreateTemp("", "external-networker-state.json")
 		Expect(err).NotTo(HaveOccurred())

--- a/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
+++ b/src/code.cloudfoundry.org/garden-external-networker/integration/integration_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Garden External Networker", func() {
 		cniPluginNames := []string{"plugin-0", "plugin-1", "plugin-2", "plugin-3"}
 		for _, name := range cniPluginNames {
 			err = link(paths.PathToFakeCNIPlugin, filepath.Join(cniPluginDir, name))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		}
 
 		config = map[string]interface{}{
@@ -461,7 +461,7 @@ func runAndWait(cmd *exec.Cmd) *gexec.Session {
 
 func createNetworkNamespace() ns.NetNS {
 	networkNS, err := nstestutils.NewNS()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	return networkNS
 }
 

--- a/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
+++ b/src/code.cloudfoundry.org/policy-server/asg_syncer/asg_syncer_test.go
@@ -346,7 +346,7 @@ var _ = Describe("ASGSyncer", func() {
 					})
 					It("doesn't return an error", func() {
 						err := asgSyncer.Poll()
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred())
 					})
 					It("doesn't update the database", func() {
 						asgSyncer.Poll()

--- a/src/code.cloudfoundry.org/policy-server/handlers/auth_middleware_test.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/auth_middleware_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Authentication middleware", func() {
 			unprotectedCallCount += 1
 			By("passing the token data to the unprotected request")
 			data := r.Context().Value(handlers.TokenDataKey)
-			Expect(data).ToNot(BeNil())
+			Expect(data).NotTo(BeNil())
 			Expect(data).To(Equal(tokenResponse))
 
 			Expect(w).To(Equal(resp))

--- a/src/code.cloudfoundry.org/policy-server/integration/create_tags_api_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/create_tags_api_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Create Tags API", func() {
 		It("creates a new tag", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			responseBody, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(responseBody)).To(MatchJSON(`{"type":"router-type","id":"router-guid","tag":"0001"}`))
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Create Tags API", func() {
 			It("returns the same tag", func() {
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				responseBody, err := io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(string(responseBody)).To(MatchJSON(`{"type":"router-type","id":"router-guid","tag":"0001"}`))
 			})
 		})

--- a/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/migrate_db_test.go
@@ -102,7 +102,7 @@ func assertMigrationsSucceeded(conn *db.ConnWrapper, conf config.Config) {
 	if conn.DriverName() == "mysql" {
 		var version string
 		err := conn.QueryRow("SELECT VERSION()").Scan(&version)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	var migrationCount int

--- a/src/code.cloudfoundry.org/policy-server/integration/timeouts/timeouts_test.go
+++ b/src/code.cloudfoundry.org/policy-server/integration/timeouts/timeouts_test.go
@@ -192,7 +192,7 @@ func migrateAndPopulateTags(dbConf db.Config) {
 		},
 	}
 	_, err = migrator.PerformMigrations(realDb.DriverName(), realDb, 0)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	tagPopulator := &store.TagPopulator{DBConnection: realDb}
 	err = tagPopulator.PopulateTables(1)

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrations_provider_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Migrations Provider", func() {
 
 	It("returns a list of migrations to perform", func() {
 		migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		expectedMigrations := migrations.PolicyServerMigrations{
 			migrations.V1ModifiedMigrationsToPerform[0],
 			migrations.V1ModifiedMigrationsToPerform[1],
@@ -73,7 +73,7 @@ var _ = Describe("Migrations Provider", func() {
 
 		It("returns a legacy v1 migration in the list of migrations to perform", func() {
 			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V1LegacyMigrationsToPerform[0],
 				migrations.V1LegacyMigrationsToPerform[1],
@@ -100,7 +100,7 @@ var _ = Describe("Migrations Provider", func() {
 
 		It("returns a legacy v2 migration in the list of migrations to perform", func() {
 			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V2LegacyMigrationsToPerform[0],
 				migrations.V2LegacyMigrationsToPerform[1],
@@ -124,7 +124,7 @@ var _ = Describe("Migrations Provider", func() {
 
 		It("returns a legacy v3 migration in the list of migrations to perform", func() {
 			migrationsToPerform, err := migrationsProvider.MigrationsToPerform()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			expectedMigrations := migrations.PolicyServerMigrations{
 				migrations.V3LegacyMigrationsToPerform[0],
 				migrations.V3LegacyMigrationsToPerform[1],

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/migrator_test.go
@@ -2014,12 +2014,12 @@ var _ = Describe("migrations", func() {
 				var guids []string
 				for range 149 {
 					guid, err := uuid.NewV4()
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					guids = append(guids, guid.String())
 				}
 				array, err := json.Marshal(guids)
 				spacesJson = string(array)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 			It("no longer adds indices", func() {
 				By("performing migration")
@@ -2625,7 +2625,7 @@ type JoinRow struct {
 
 func ExpectAssociatedSpacesToConsistOf(realDb *db.ConnWrapper, table string, expectedRows []JoinRow) {
 	rows, err := realDb.Query(fmt.Sprintf("SELECT security_group_guid, space_guid FROM %s_security_groups_spaces", table))
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	if len(expectedRows) == 0 {
 		ExpectWithOffset(1, scanCountRow(rows)).To(Equal(0))
 	} else {
@@ -2633,7 +2633,7 @@ func ExpectAssociatedSpacesToConsistOf(realDb *db.ConnWrapper, table string, exp
 		for rows.Next() {
 			var sg, space string
 			err := rows.Scan(&sg, &space)
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			receivedRows = append(receivedRows, JoinRow{
 				SecurityGroup: sg,
 				Space:         space,

--- a/src/code.cloudfoundry.org/policy-server/store/security_groups_store_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/security_groups_store_test.go
@@ -28,9 +28,9 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 	getNumRecords := func(table string) int {
 		var count int
-		ExpectWithOffset(1, realDb).ToNot(BeNil())
+		ExpectWithOffset(1, realDb).NotTo(BeNil())
 		err := realDb.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		return count
 	}
 
@@ -87,13 +87,13 @@ var _ = Describe("SecurityGroupsStore", func() {
 			}}
 
 			err := securityGroupsStore.Replace(securityGroups)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("when no space guids are provided", func() {
 			It("returns empty list", func() {
 				securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(0))
 			})
@@ -102,7 +102,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("search by staging space guid", func() {
 			It("fetches asgs attached to provided spaces", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-b"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -119,7 +119,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("search by running space guid", func() {
 			It("fetches attached to provided spaces", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-a"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -135,7 +135,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("when one of the spaces of the security group wth multiple spaces is requested", func() {
 			It("returns that security group", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-e"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
 					Guid:              "third-guid",
@@ -151,7 +151,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("when the space that has multiple groups is requested", func() {
 			It("returns all security groups in that space, ordered by id", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-d"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(len(securityGroups)).To(Equal(2))
 				Expect(securityGroups).To(Equal([]store.SecurityGroup{
 					{
@@ -174,7 +174,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("when multiple spaces are requested", func() {
 			It("returns all security groups in all requested spaces", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-e", "space-d"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(len(securityGroups)).To(Equal(2))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
 					Guid:              "third-guid",
@@ -196,7 +196,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 		Context("when a page has a limit", func() {
 			It("returns the requested limit", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-e", "space-d"}, store.Page{Limit: 1, From: 3})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -209,7 +209,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				Expect(pagination).To(Equal(store.Pagination{Next: 4}))
 
 				securityGroups, pagination, err = securityGroupsStore.BySpaceGuids([]string{"space-e", "space-d"}, store.Page{Limit: 1, From: 4})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
 					Guid:              "fourth-guid",
@@ -239,12 +239,12 @@ var _ = Describe("SecurityGroupsStore", func() {
 				}, {}}
 
 				err := securityGroupsStore.Replace(securityGroups)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("returns it even if it is not requested by space guid", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-b"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(2))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -266,7 +266,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 			It("returns it when no space guids are provided", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -297,12 +297,12 @@ var _ = Describe("SecurityGroupsStore", func() {
 				}, {}}
 
 				err := securityGroupsStore.Replace(securityGroups)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("returns it even if it is not requested by space guid", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{"space-b"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(2))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -323,7 +323,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 			It("returns it when no space guids are requested", func() {
 				securityGroups, pagination, err := securityGroupsStore.BySpaceGuids([]string{}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(securityGroups)).To(Equal(1))
 				Expect(securityGroups).To(ConsistOf(store.SecurityGroup{
@@ -377,7 +377,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 			emptyRules = []store.SecurityGroup{}
 
 			err := securityGroupsStore.Replace(initialRules)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("updates last updated field", func() {
@@ -396,20 +396,20 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 		It("replaces the spaceSecurityGroupsStore data with the newly provided data", func() {
 			err := securityGroupsStore.Replace(newRules)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(securityGroups).To(ConsistOf(newRules))
 		})
 
 		It("works if data is the same", func() {
 			err := securityGroupsStore.Replace(initialRules)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(securityGroups).To(ConsistOf(initialRules))
 		})
@@ -419,10 +419,10 @@ var _ = Describe("SecurityGroupsStore", func() {
 			})
 			It("deletes the record", func() {
 				err := securityGroupsStore.Replace(newRules)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(securityGroups).To(ConsistOf(newRules))
 			})
@@ -453,10 +453,10 @@ var _ = Describe("SecurityGroupsStore", func() {
 			})
 			It("only updates the two changing", func() {
 				err := securityGroupsStore.Replace(newRules)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(securityGroups).To(ConsistOf(newRules))
 
 				Eventually(testLogger).Should(gbytes.Say(`"num_records":2`))
@@ -489,7 +489,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes the association for that space from that ASG", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					results := map[string][]string{}
 					query := helpers.RebindForSQLDialect("SELECT security_group_guid, space_guid FROM running_security_groups_spaces WHERE security_group_guid = ? ORDER BY space_guid", securityGroupsStore.Conn.DriverName())
@@ -513,7 +513,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes the association for that space from that ASG", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					results := map[string][]string{}
 					query := helpers.RebindForSQLDialect("SELECT security_group_guid, space_guid FROM staging_security_groups_spaces WHERE security_group_guid = ? ORDER BY space_guid", securityGroupsStore.Conn.DriverName())
@@ -537,7 +537,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes all associations for that ASG", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					var associations int
 					query := helpers.RebindForSQLDialect("SELECT COUNT(*) FROM staging_security_groups_spaces WHERE security_group_guid = ?", securityGroupsStore.Conn.DriverName())
@@ -547,7 +547,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 					err = securityGroupsStore.Conn.QueryRow("SELECT COUNT(*) FROM staging_security_groups_spaces").Scan(&associations)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(associations).ToNot(Equal(0))
+					Expect(associations).NotTo(Equal(0))
 				})
 			})
 
@@ -558,7 +558,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes all associations from that ASG", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					var associations int
 					query := helpers.RebindForSQLDialect("SELECT COUNT(*) FROM running_security_groups_spaces WHERE security_group_guid = ?", securityGroupsStore.Conn.DriverName())
@@ -568,7 +568,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 
 					err = securityGroupsStore.Conn.QueryRow("SELECT COUNT(*) FROM running_security_groups_spaces").Scan(&associations)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(associations).ToNot(Equal(0))
+					Expect(associations).NotTo(Equal(0))
 				})
 			})
 			Context("when no more running asgs are directly bound", func() {
@@ -578,7 +578,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes all space associations from from all ASGs", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					var associations int
 					err = securityGroupsStore.Conn.QueryRow("SELECT COUNT(*) FROM running_security_groups_spaces").Scan(&associations)
@@ -593,7 +593,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 				})
 				It("removes all space associations from from all ASGs", func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					var associations int
 					err = securityGroupsStore.Conn.QueryRow("SELECT COUNT(*) FROM staging_security_groups_spaces").Scan(&associations)
@@ -604,9 +604,9 @@ var _ = Describe("SecurityGroupsStore", func() {
 			Context("when the only updated ASGs are ones that don't have space bindings", func() {
 				BeforeEach(func() {
 					err := securityGroupsStore.Replace(newRules)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					Expect(securityGroups).To(ConsistOf(newRules))
 
 					newRules = append(newRules, store.SecurityGroup{
@@ -621,7 +621,7 @@ var _ = Describe("SecurityGroupsStore", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 
 					Expect(securityGroups).To(ConsistOf(newRules))
 
@@ -630,15 +630,15 @@ var _ = Describe("SecurityGroupsStore", func() {
 		})
 		Context("when no more asgs exist", func() {
 			It("removes all ASGs", func() {
-				Expect(getNumRecords("security_groups")).ToNot(Equal(0))
-				Expect(getNumRecords("staging_security_groups_spaces")).ToNot(Equal(0))
-				Expect(getNumRecords("running_security_groups_spaces")).ToNot(Equal(0))
+				Expect(getNumRecords("security_groups")).NotTo(Equal(0))
+				Expect(getNumRecords("staging_security_groups_spaces")).NotTo(Equal(0))
+				Expect(getNumRecords("running_security_groups_spaces")).NotTo(Equal(0))
 
 				err := securityGroupsStore.Replace(emptyRules)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(securityGroups).To(ConsistOf(emptyRules))
 				time.Sleep(1 * time.Second)
@@ -658,10 +658,10 @@ var _ = Describe("SecurityGroupsStore", func() {
 			})
 			It("creates new data", func() {
 				err := securityGroupsStore.Replace(newRules)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				securityGroups, _, err := securityGroupsStore.BySpaceGuids([]string{"first-space", "second-space", "third-space"}, store.Page{})
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(securityGroups).To(ConsistOf(newRules))
 

--- a/src/code.cloudfoundry.org/policy-server/store/store_test.go
+++ b/src/code.cloudfoundry.org/policy-server/store/store_test.go
@@ -1299,5 +1299,5 @@ func migrate(realDb *db.ConnWrapper) {
 		},
 	}
 	_, err := migrator.PerformMigrations(realDb.DriverName(), realDb, 0)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/src/code.cloudfoundry.org/service-discovery-controller/config/config_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/config/config_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Config", func() {
 	Context("when created from valid JSON", func() {
 		It("contains the values in the JSON", func() {
 			parsedConfig, err := NewConfig(configJSON)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(parsedConfig.Address).To(Equal("example.com"))
 			Expect(parsedConfig.Port).To(Equal("80053"))
@@ -77,13 +77,13 @@ var _ = Describe("Config", func() {
 		It("interprets the configuration correctly", func() {
 			var configBeingAltered Config
 			err := json.Unmarshal(configJSON, &configBeingAltered)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			_, serverCertPath, _, serverCert := testhelpers.GenerateCaAndMutualTlsCerts()
 			_, clientCertPath, clientKeyPath, clientCert := testhelpers.GenerateCaAndMutualTlsCerts()
 
 			parsedCert, err := x509.ParseCertificate(serverCert.Certificate[0])
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			expectedSubject := parsedCert.RawSubject
 
 			configBeingAltered.Nats = NatsConfig{
@@ -104,10 +104,10 @@ var _ = Describe("Config", func() {
 			}
 
 			configJSON, err = json.Marshal(configBeingAltered)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			parsedConfig, err := NewConfig(configJSON)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(parsedConfig.NatsServers()).To(ConsistOf([]string{
 				"nats://tls-nats-server-1:33",
@@ -116,7 +116,7 @@ var _ = Describe("Config", func() {
 
 			Expect(parsedConfig.Nats.TLSEnabled).To(Equal(true))
 
-			Expect(parsedConfig.Nats.CAPool).ToNot(BeNil())
+			Expect(parsedConfig.Nats.CAPool).NotTo(BeNil())
 			//lint:ignore SA1019 - ignoring tlsCert.RootCAs.Subjects is deprecated ERR because cert does not come from SystemCertPool.
 			poolSubjects := parsedConfig.Nats.CAPool.Subjects()
 			Expect(string(poolSubjects[0])).To(Equal(string(expectedSubject)))

--- a/src/code.cloudfoundry.org/service-discovery-controller/main_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/main_test.go
@@ -62,12 +62,12 @@ var _ = Describe("Service Discovery Controller process", func() {
 		).Client(
 			tlsconfig.WithAuthorityFromFile(natsServerCAPath),
 		)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		natsTlsConfig, err = tlsconfig.Build(
 			tlsconfig.WithIdentity(natsServerCert),
 			tlsconfig.WithInternalServiceDefaults(),
 		).Server(tlsconfig.WithClientAuthenticationFromFile(natsClientCAPath))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		natsServerPort = ports.PickAPort()
 		natsServer = RunNatsServerOnPort(natsServerPort, natsTlsConfig)
 
@@ -119,7 +119,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 			startCmd := exec.Command(pathToServer, "-c", configPath)
 			var err error
 			session, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session, 6*time.Second).Should(gbytes.Say("service-discovery-controller.server-started"))
 
@@ -139,7 +139,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 			register(routeEmitter, "192.168.0.11", "large-id.internal.local.")
 			register(routeEmitter, "192.168.0.12", "large-id.internal.local.")
 			register(routeEmitter, "192.168.0.13", "large-id.internal.local.")
-			Expect(routeEmitter.Flush()).ToNot(HaveOccurred())
+			Expect(routeEmitter.Flush()).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -160,7 +160,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 			requestLogChange("debug", logLevelEndpointPort)
 
 			unregister(routeEmitter, "192.168.0.1", "app-id.internal.local.")
-			Expect(routeEmitter.Flush()).ToNot(HaveOccurred())
+			Expect(routeEmitter.Flush()).NotTo(HaveOccurred())
 
 			client := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert)
 			Eventually(func() string {
@@ -170,7 +170,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 					return "server is not listening yet"
 				}
 				respBody, err := io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return string(respBody)
 			}).Should(MatchJSON(`{
 				"env": "",
@@ -226,9 +226,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 		It("should return a http app json", func() {
 			url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 			resp, err := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert).Get(url)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			respBody, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(respBody).To(MatchJSON(`{
 				"env": "",
@@ -258,9 +258,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 		It("should return a http large json", func() {
 			url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/large-id.internal.local.", port)
 			resp, err := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert).Get(url)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			respBody, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(respBody).To(MatchJSON(`{
 				"env": "",
@@ -394,10 +394,10 @@ var _ = Describe("Service Discovery Controller process", func() {
 			Eventually(func() []byte {
 				url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 				resp, err := client.Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				respBody, err := io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				return respBody
 			}, waitDuration).Should(MatchJSON(`{ "env": "", "hosts": [], "service": "" }`))
@@ -407,9 +407,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 			It("should return a map of all hostnames to ips", func() {
 				url := fmt.Sprintf("https://127.0.0.1:%d/routes", port)
 				resp, err := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert).Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				respBody, err := io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(respBody).To(Or(MatchJSON(`{
 					"addresses": [{
@@ -510,9 +510,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 				Eventually(func() string {
 					url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 					resp, err := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert).Get(url)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					respBody, err := io.ReadAll(resp.Body)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					return string(respBody)
 				}).Should(MatchJSON(`{
 					"env": "",
@@ -563,7 +563,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 				JustBeforeEach(func() {
 					url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 					_, err := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert).Get(url)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("emits a dns request metric", func() {
@@ -600,10 +600,10 @@ var _ = Describe("Service Discovery Controller process", func() {
 					Consistently(func() []byte {
 						url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 						resp, err := client.Get(url)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred())
 
 						respBody, err := io.ReadAll(resp.Body)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred())
 
 						return respBody
 					}, waitDuration).Should(MatchJSON(`{
@@ -636,10 +636,10 @@ var _ = Describe("Service Discovery Controller process", func() {
 					Eventually(func() []byte {
 						url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 						resp, err := client.Get(url)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred())
 
 						respBody, err := io.ReadAll(resp.Body)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).NotTo(HaveOccurred())
 
 						return respBody
 					}, waitDuration).Should(MatchJSON(`{
@@ -681,9 +681,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 				client := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert)
 				url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 				_, err := client.Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
-				Expect(session).ToNot(gbytes.Say("HTTPServer access"))
+				Expect(session).NotTo(gbytes.Say("HTTPServer access"))
 			})
 
 			It("logs at debug level when configured", func() {
@@ -691,7 +691,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 				client := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert)
 				url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 				_, err := client.Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(session).Should(gbytes.Say("HTTPServer access"))
 			})
@@ -703,9 +703,9 @@ var _ = Describe("Service Discovery Controller process", func() {
 				client := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert)
 				url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 				_, err := client.Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 
-				Expect(session).ToNot(gbytes.Say("HTTPServer access"))
+				Expect(session).NotTo(gbytes.Say("HTTPServer access"))
 			})
 		})
 
@@ -746,12 +746,12 @@ var _ = Describe("Service Discovery Controller process", func() {
 				url := fmt.Sprintf("https://127.0.0.1:%d/v1/registration/app-id.internal.local.", port)
 				client := testhelpers.NewClient(testhelpers.CertPool(caFile), clientCert)
 				resp, err := client.Get(url)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 
 				Eventually(func() int {
 					resp, err := client.Get(url)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 					return resp.StatusCode
 				}).Should(Equal(http.StatusOK))
 			})
@@ -773,7 +773,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 			startCmd := exec.Command(pathToServer, "-c", configPath)
 			var err error
 			session, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session).Should(gexec.Exit(2))
 			Eventually(session, 5*time.Second).Should(gbytes.Say("service-discovery-controller.log-level-server.Listen and serve exited with error:"))
@@ -813,7 +813,7 @@ var _ = Describe("Service Discovery Controller process", func() {
 			startCmd := exec.Command(pathToServer, "-c", configPath)
 			var err error
 			session, err = gexec.Start(startCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(session, 5*time.Second).Should(gexec.Exit(2))
 			Expect(session).To(gbytes.Say("service-discovery-controller.*unable to create nats connection: nats: no servers available for connection"))
 		})
@@ -825,7 +825,7 @@ func requestLogChange(logLevel string, port int) *http.Response {
 	postBody := strings.NewReader(logLevel)
 	url := fmt.Sprintf("http://localhost:%d/log-level", port)
 	response, err := client.Post(url, "text/plain", postBody)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	return response
 }
 
@@ -835,7 +835,7 @@ func register(routeEmitter *nats.Conn, ip string, url string) {
 		Data:    []byte(fmt.Sprintf(`{"host": "%s","uris":["%s"]}`, ip, url)),
 	}
 
-	Expect(routeEmitter.PublishMsg(&natsRegistryMsg)).ToNot(HaveOccurred())
+	Expect(routeEmitter.PublishMsg(&natsRegistryMsg)).NotTo(HaveOccurred())
 }
 
 func unregister(routeEmitter *nats.Conn, ip string, url string) {
@@ -844,7 +844,7 @@ func unregister(routeEmitter *nats.Conn, ip string, url string) {
 		Data:    []byte(fmt.Sprintf(`{"host": "%s","uris":["%s"]}`, ip, url)),
 	}
 
-	Expect(routeEmitter.PublishMsg(&natsRegistryMsg)).ToNot(HaveOccurred())
+	Expect(routeEmitter.PublishMsg(&natsRegistryMsg)).NotTo(HaveOccurred())
 }
 
 func newFakeRouteEmitter(natsUrl string, natsClientTlsConfig *tls.Config) *nats.Conn {
@@ -855,12 +855,12 @@ func newFakeRouteEmitter(natsUrl string, natsClientTlsConfig *tls.Config) *nats.
 
 func writeConfigFile(configJson string) string {
 	configFile, err := os.CreateTemp(os.TempDir(), "sd_config")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	configPath := configFile.Name()
 
 	err = os.WriteFile(configPath, []byte(configJson), os.ModePerm)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	return configPath
 }

--- a/src/code.cloudfoundry.org/service-discovery-controller/mbus/subscriber_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/mbus/subscriber_test.go
@@ -48,12 +48,12 @@ var _ = Describe("Subscriber", func() {
 
 		startMsgChan = make(chan *nats.Msg, 1)
 		_, err := fakeRouteEmitter.ChanSubscribe("service-discovery.start", startMsgChan)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		greetMsgChan = make(chan *nats.Msg, 1)
 
 		_, err = fakeRouteEmitter.ChanSubscribe("service-discovery.greet.test.response", greetMsgChan)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(fakeRouteEmitter.Flush()).To(Succeed())
 
@@ -74,7 +74,7 @@ var _ = Describe("Subscriber", func() {
 		warmingDuration = time.Duration(60) * time.Second
 
 		subscriber = NewSubscriber(provider, subOpts, warmingDuration, addressTable, localIP, messageRecorder, subcriberLogger, fakeClock)
-		Expect(subscriber.RunOnce()).ToNot(HaveOccurred())
+		Expect(subscriber.RunOnce()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -97,15 +97,15 @@ var _ = Describe("Subscriber", func() {
 
 		Eventually(startMsgChan, 4).Should(Receive(&msg))
 
-		Expect(msg).ToNot(BeNil())
+		Expect(msg).NotTo(BeNil())
 
 		err := json.Unmarshal(msg.Data, &serviceDiscoveryData)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(serviceDiscoveryData.Id).To(Equal(subOpts.ID))
 		Expect(serviceDiscoveryData.MinimumRegisterIntervalInSeconds).To(Equal(subOpts.MinimumRegisterIntervalInSeconds))
 		Expect(serviceDiscoveryData.PruneThresholdInSeconds).To(Equal(subOpts.PruneThresholdInSeconds))
-		Expect(serviceDiscoveryData.Host).ToNot(BeEmpty())
+		Expect(serviceDiscoveryData.Host).NotTo(BeEmpty())
 
 		Eventually(subcriberLogger).Should(glager.HaveLogged(
 			glager.Info(
@@ -120,15 +120,15 @@ var _ = Describe("Subscriber", func() {
 		var msg *nats.Msg
 		var serviceDiscoveryData ServiceDiscoveryStartMessage
 		Eventually(greetMsgChan, 10*time.Second).Should(Receive(&msg))
-		Expect(msg).ToNot(BeNil())
+		Expect(msg).NotTo(BeNil())
 
 		err := json.Unmarshal(msg.Data, &serviceDiscoveryData)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		Expect(serviceDiscoveryData.Id).To(Equal(subOpts.ID))
 		Expect(serviceDiscoveryData.MinimumRegisterIntervalInSeconds).To(Equal(subOpts.MinimumRegisterIntervalInSeconds))
 		Expect(serviceDiscoveryData.PruneThresholdInSeconds).To(Equal(subOpts.PruneThresholdInSeconds))
-		Expect(serviceDiscoveryData.Host).ToNot(BeEmpty())
+		Expect(serviceDiscoveryData.Host).NotTo(BeEmpty())
 
 		Eventually(subcriberLogger).Should(glager.HaveLogged(
 			glager.Info(
@@ -141,25 +141,25 @@ var _ = Describe("Subscriber", func() {
 			msgChan := make(chan *nats.Msg, 1)
 
 			_, err := fakeRouteEmitter.ChanSubscribe("service-discovery.greet-1.test.response", msgChan)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeRouteEmitter.Flush()).To(Succeed())
 
 			err = fakeRouteEmitter.PublishRequest("service-discovery.greet", "service-discovery.greet-1.test.response", []byte{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeRouteEmitter.Flush()).To(Succeed())
 
 			var msg *nats.Msg
 			var serviceDiscoveryData ServiceDiscoveryStartMessage
 			Eventually(msgChan, 4*time.Second).Should(Receive(&msg))
-			Expect(msg).ToNot(BeNil())
+			Expect(msg).NotTo(BeNil())
 
 			err = json.Unmarshal(msg.Data, &serviceDiscoveryData)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(serviceDiscoveryData.Id).To(Equal(subOpts.ID))
 			Expect(serviceDiscoveryData.MinimumRegisterIntervalInSeconds).To(Equal(subOpts.MinimumRegisterIntervalInSeconds))
 			Expect(serviceDiscoveryData.PruneThresholdInSeconds).To(Equal(subOpts.PruneThresholdInSeconds))
-			Expect(serviceDiscoveryData.Host).ToNot(BeEmpty())
+			Expect(serviceDiscoveryData.Host).NotTo(BeEmpty())
 		})
 	})
 
@@ -198,7 +198,7 @@ var _ = Describe("Subscriber", func() {
 		BeforeEach(func() {
 			msgChan = make(chan *nats.Msg, 1)
 			_, err := fakeRouteEmitter.ChanSubscribe("service-discovery.start", msgChan)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeRouteEmitter.Flush()).To(Succeed())
 
 			By("gnatsd server stops", func() {
@@ -221,15 +221,15 @@ var _ = Describe("Subscriber", func() {
 			var serviceDiscoveryData ServiceDiscoveryStartMessage
 			Eventually(msgChan, 30*time.Second).Should(Receive(&msg))
 
-			Expect(msg).ToNot(BeNil())
+			Expect(msg).NotTo(BeNil())
 
 			err := json.Unmarshal(msg.Data, &serviceDiscoveryData)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(serviceDiscoveryData.Id).To(Equal(subOpts.ID))
 			Expect(serviceDiscoveryData.MinimumRegisterIntervalInSeconds).To(Equal(subOpts.MinimumRegisterIntervalInSeconds))
 			Expect(serviceDiscoveryData.PruneThresholdInSeconds).To(Equal(subOpts.PruneThresholdInSeconds))
-			Expect(serviceDiscoveryData.Host).ToNot(BeEmpty())
+			Expect(serviceDiscoveryData.Host).NotTo(BeEmpty())
 			Expect(serviceDiscoveryData.Host).To(Equal("192.168.0.1"))
 		})
 		It("logs a message", func() {

--- a/src/code.cloudfoundry.org/service-discovery-controller/routes/metrics_recorder_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/routes/metrics_recorder_test.go
@@ -57,7 +57,7 @@ var _ = Describe("MetricsRecorder", func() {
 		It("should not race", func() {
 			Eventually(func() float64 {
 				count, err := metricsRecorder.Getter()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				return count
 			}, "2s").Should(Equal(float64(2)))
 		})

--- a/src/code.cloudfoundry.org/service-discovery-controller/routes/server_test.go
+++ b/src/code.cloudfoundry.org/service-discovery-controller/routes/server_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Server", func() {
 			}).Should(BeNil())
 
 			respBodyBytes, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			respBody = string(respBodyBytes)
 		})
 
@@ -164,7 +164,7 @@ var _ = Describe("Server", func() {
 			Expect(metricsSender.SendDurationCallCount()).To(BeNumerically(">=", 1))
 			name, time := metricsSender.SendDurationArgsForCall(0)
 			Expect(name).To(Equal("addressTableLookupTime"))
-			Expect(time.String()).ToNot(Equal("0s"))
+			Expect(time.String()).NotTo(Equal("0s"))
 		})
 	})
 
@@ -187,7 +187,7 @@ var _ = Describe("Server", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 
 			respBodyBytes, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			respBody := string(respBodyBytes)
 			Expect(respBody).To(ContainSubstring("address table is not warm"))
 		})

--- a/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/asg_overlay_interaction_test.go
@@ -69,14 +69,14 @@ var _ = Describe("ASGs and Overlay Policy interaction", func() {
 
 				app2Curl := fmt.Sprintf("curl --fail --connect-timeout 10 http://%s:8080/echosourceip", app2.internalIP)
 				session := cf.Cf("ssh", appProxy, "-i", app1.index, "-c", app2Curl)
-				Expect(session.Wait(Timeout_Push)).ToNot(gexec.Exit(0))
+				Expect(session.Wait(Timeout_Push)).NotTo(gexec.Exit(0))
 
 				By("checking connectivity fails between two instances on the different cells")
 				app1, app2 = findTwoInstancesOnDifferentHosts(appInstances)
 
 				app2Curl = fmt.Sprintf("curl --fail --connect-timeout 10 http://%s:8080/echosourceip", app2.internalIP)
 				session = cf.Cf("ssh", appProxy, "-i", app1.index, "-c", app2Curl)
-				Expect(session.Wait(Timeout_Push)).ToNot(gexec.Exit(0))
+				Expect(session.Wait(Timeout_Push)).NotTo(gexec.Exit(0))
 			})
 		})
 

--- a/src/code.cloudfoundry.org/test/acceptance/asg_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/asg_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Application Security Groups", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		respBytes, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 		resp.Body.Close()
 		Expect(respBytes).To(MatchRegexp("refused"))
 
@@ -77,7 +77,7 @@ var _ = Describe("Application Security Groups", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				respBytes, err = io.ReadAll(resp.Body)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 				resp.Body.Close()
 				return string(respBytes)
 			}).Should(MatchRegexp("refused"))
@@ -91,7 +91,7 @@ var _ = Describe("Application Security Groups", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			respBytes, err = io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			resp.Body.Close()
 			return string(respBytes)
 		}).WithTimeout(180 * time.Second).Should(MatchRegexp("version"))
@@ -106,7 +106,7 @@ var _ = Describe("Application Security Groups", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			respBytes, err = io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			resp.Body.Close()
 			response := string(respBytes)
 			Expect(response).To(MatchRegexp("version"))
@@ -120,7 +120,7 @@ var _ = Describe("Application Security Groups", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			respBytes, err = io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			resp.Body.Close()
 			return string(respBytes)
 		}).WithTimeout(180 * time.Second).Should(MatchRegexp("refused"))

--- a/src/code.cloudfoundry.org/test/acceptance/init_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/init_test.go
@@ -229,7 +229,7 @@ func findTwoInstancesOnTheSameHost(apps []AppInstance) (AppInstance, AppInstance
 		hostsToApps[app.hostIdentifier] = app
 	}
 
-	Expect(errors.New("failed to find two instances on the same host")).ToNot(HaveOccurred())
+	Expect(errors.New("failed to find two instances on the same host")).NotTo(HaveOccurred())
 	return AppInstance{}, AppInstance{}
 }
 
@@ -240,6 +240,6 @@ func findTwoInstancesOnDifferentHosts(apps []AppInstance) (AppInstance, AppInsta
 		}
 	}
 
-	Expect(errors.New("failed to find two instances on different hosts")).ToNot(HaveOccurred())
+	Expect(errors.New("failed to find two instances on different hosts")).NotTo(HaveOccurred())
 	return AppInstance{}, AppInstance{}
 }

--- a/src/code.cloudfoundry.org/test/acceptance/space_developer_test.go
+++ b/src/code.cloudfoundry.org/test/acceptance/space_developer_test.go
@@ -35,7 +35,7 @@ var _ = Describe("space developer policy configuration", func() {
 	BeforeEach(func() {
 		var err error
 		uaaAPI, err = uaa.New(getUAABaseURL(), uaa.WithClientCredentials("admin", testConfig.AdminSecret, uaa.OpaqueToken), uaa.WithSkipSSLValidation(true))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		policyClient = policy_client.NewExternal(lagertest.NewTestLogger("test"),
 			&http.Client{

--- a/src/code.cloudfoundry.org/test/performance-sd/deploy/deploy_suite_test.go
+++ b/src/code.cloudfoundry.org/test/performance-sd/deploy/deploy_suite_test.go
@@ -46,7 +46,7 @@ func TestPerformance(t *testing.T) {
 				"-v", fmt.Sprintf("nats_password=%s", config.NatsPassword),
 				"-v", fmt.Sprintf("nats_ip=%s", config.NatsURL))
 			session, err := gexec.Start(cmd, os.Stdout, os.Stderr)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(session, 20*time.Minute).Should(gexec.Exit(0))
 		})


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We had mixed usage throughout our tests, but many more NotTos than ToNots.


Backward Compatibility
---------------
Breaking Change? no