### PR TITLE
remove link to expired doc

### DIFF
--- a/docs/03-troubleshooting.md
+++ b/docs/03-troubleshooting.md
@@ -48,16 +48,6 @@ tags: [cf-networking-release]
 <!-- vim-markdown-toc -->
 # Known Issues
 
-### Apps stop running after a deploy when using dynamic ASGs with icmp any rule
-  When dynamic ASGs are enabled, the vxlan policy agent is unable to clean up
-  ICMP any rules. Undocumented iptables behavior with ICMP any rules causes a
-  cleanup failure, which causes a container creation failure, which prevents any
-  apps from starting. This results in a vxlan policy agent error `iptables: Bad
-  rule (does a matching rule exist in that chain?)` or `exit status 1: iptables:
-  No chain/target/match by that name.`.
-
-  For more information see [this doc](04-b-dynamic-asgs-ki-icmp-any-rules.md).
-
 ### Compatibility with VMware NSX for vSphere 6.2.3+
 
   When using VMware NSX for vSphere 6.2.3+, the default VXLAN port of 4789 used


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This expired doc was removed: https://github.com/cloudfoundry/cf-networking-release/commit/2f8d3210f2191dfb5939c351364534103b1af929

So this commit removes the link to the deleted doc. 

Backward Compatibility
---------------
Breaking Change? No
