### PR TITLE
Create open-api yaml for cf-networking policies

### DIFF
--- a/docs/swagger/README.md
+++ b/docs/swagger/README.md
@@ -1,0 +1,117 @@
+# CF Networking API Documentation
+
+This directory contains the OpenAPI documentation for the Cloud Foundry Networking API.
+
+## Generated Files
+
+- **`openapi.yaml`** - OpenAPI 3.1 specification in YAML format
+- **`openapi.json`** - OpenAPI 3.1 specification in JSON format
+- **`index.html`** - Swagger UI viewer for the documentation
+- **`README.md`** - This documentation file
+
+## API Overview
+
+The CF Networking API provides endpoints for managing network policies and tags in Cloud Foundry:
+
+### 🔐 Authentication
+
+All endpoints require OAuth2 authentication with appropriate scopes:
+- **`network.admin`** - Full access to all policy operations
+- **`network.write`** - Write access to policies (for space developers)
+
+### 📋 Endpoints
+
+| Method | Path | Description | Required Scope |
+|--------|------|-------------|----------------|
+| GET | `/policies` | List network policies | `network.write` |
+| POST | `/policies` | Create network policies | `network.write` |
+| POST | `/policies/delete` | Delete network policies | `network.write` |
+| GET | `/tags` | List tag mappings | `network.admin` |
+
+## Viewing the Documentation
+
+### Option 1: Swagger Editor (Online)
+1. Go to [https://editor.swagger.io/](https://editor.swagger.io/)
+2. Copy the content of `openapi.yaml` and paste it in the editor
+
+### Option 2: Local Swagger UI
+1. Serve this directory with a local web server:
+   ```bash
+   # Using Python
+   python -m http.server 8000
+   
+   # Using Node.js
+   npx http-server
+   
+   # Using Go
+   go run -m http.FileServer -addr=:8000 .
+   ```
+2. Open http://localhost:8000 in your browser
+
+### Option 3: Swagger UI Docker
+```bash
+docker run -p 8080:8080 -v $(pwd):/usr/share/nginx/html -e SWAGGER_JSON=/openapi.json swaggerapi/swagger-ui
+```
+
+## Regenerating Documentation
+
+To regenerate the OpenAPI specification after code changes:
+
+```bash
+./scripts/generate-swagger.sh
+```
+
+This script will:
+1. Install `swaggo/swag` v2 if not present
+2. Scan the CF Networking codebase for Swag comments  
+3. Generate OpenAPI 3.1 files: `openapi.yaml` and `openapi.json`
+
+## API Usage Examples
+
+### Authentication
+```bash
+# Get OAuth token
+export TOKEN=$(cf oauth-token)
+
+# Use with API
+curl -H "Authorization: $TOKEN" \
+  https://api.bosh-lite.com/networking/v1/external/policies
+```
+
+### List Policies
+```bash
+curl -H "Authorization: $TOKEN" \
+  "https://api.bosh-lite.com/networking/v1/external/policies"
+```
+
+### Create Policy
+```bash
+curl -H "Authorization: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{
+    "policies": [
+      {
+        "source": {"id": "app-1-guid"},
+        "destination": {
+          "id": "app-2-guid",
+          "protocol": "tcp",
+          "ports": {"start": 8080, "end": 8080}
+        }
+      }
+    ]
+  }' \
+  "https://api.bosh-lite.com/networking/v1/external/policies"
+```
+
+## Schema Information
+
+The API uses these main data structures:
+
+- **Policy** - Defines network connectivity between source and destination applications
+- **Source/Destination** - Application identifiers and network configuration
+- **Ports** - Port range specification (start/end)
+- **Tag** - Unique identifier assigned to policy groups
+- **PoliciesPayload** - Container for multiple policies with count information
+
+For detailed schema information, see the generated `openapi.yaml` file or view in Swagger UI.

--- a/docs/swagger/index.html
+++ b/docs/swagger/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CF Networking API Documentation</title>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.52.5/swagger-ui.css" />
+  <style>
+    html {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+    *, *:before, *:after {
+      box-sizing: inherit;
+    }
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+
+  <script src="https://unpkg.com/swagger-ui-dist@3.52.5/swagger-ui-bundle.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@3.52.5/swagger-ui-standalone-preset.js"></script>
+  <script>
+    window.onload = function() {
+      // Load the OpenAPI 3.x spec
+      const ui = SwaggerUIBundle({
+        url: './openapi.yaml',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout",
+        validatorUrl: null
+      });
+    };
+  </script>
+</body>
+</html>

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -1,0 +1,414 @@
+{
+    "components": {
+        "schemas": {
+            "Destination": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "ips": {
+                        "items": {
+                            "$ref": "#/components/schemas/IPRange"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "ports": {
+                        "$ref": "#/components/schemas/Ports"
+                    },
+                    "protocol": {
+                        "type": "string"
+                    },
+                    "tag": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorResponse": {
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "additionalProperties": {},
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "IPRange": {
+                "properties": {
+                    "end": {
+                        "type": "string"
+                    },
+                    "start": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "PoliciesPayload": {
+                "properties": {
+                    "policies": {
+                        "items": {
+                            "$ref": "#/components/schemas/Policy"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "total_policies": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "Policy": {
+                "properties": {
+                    "destination": {
+                        "$ref": "#/components/schemas/Destination"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/Source"
+                    }
+                },
+                "type": "object"
+            },
+            "Ports": {
+                "properties": {
+                    "end": {
+                        "type": "integer"
+                    },
+                    "start": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "Source": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "tag": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Tag": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "tag": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "contact": {
+            "name": "Cloud Foundry Networking Team"
+        },
+        "description": "API for managing network policies and tags in Cloud Foundry",
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "title": "CF Networking API",
+        "version": "1.0"
+    },
+    "externalDocs": {
+        "description": "",
+        "url": ""
+    },
+    "paths": {
+        "/policies": {
+            "get": {
+                "description": "Retrieves network policies. Can optionally filter policies by source ID, destination ID, or specific policy group IDs.",
+                "parameters": [
+                    {
+                        "description": "Comma-separated policy group ID values",
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Comma-separated source policy group ID values",
+                        "in": "query",
+                        "name": "source_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Comma-separated destination policy group ID values",
+                        "in": "query",
+                        "name": "dest_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PoliciesPayload"
+                                }
+                            }
+                        },
+                        "description": "Successfully retrieved policies"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2Application": [
+                            "network.write"
+                        ]
+                    }
+                ],
+                "summary": "List policies",
+                "tags": [
+                    "policies"
+                ]
+            },
+            "post": {
+                "description": "Creates network policies to allow traffic between applications. Policies define which source applications can reach which destination applications on specified protocols and ports.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PoliciesPayload",
+                                        "summary": "policies",
+                                        "description": "Policies to create"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Policies to create",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Policies created successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Invalid request body or validation failed"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden - insufficient permissions or policy quota exceeded"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2Application": [
+                            "network.write"
+                        ]
+                    }
+                ],
+                "summary": "Create policies",
+                "tags": [
+                    "policies"
+                ]
+            }
+        },
+        "/policies/delete": {
+            "post": {
+                "description": "Deletes existing network policies. This removes the network connectivity rules between the specified source and destination applications.",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PoliciesPayload",
+                                        "summary": "policies",
+                                        "description": "Policies to delete"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Policies to delete",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Policies deleted successfully"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Invalid request body or validation failed"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden - insufficient permissions"
+                    },
+                    "406": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported API version"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2Application": [
+                            "network.write"
+                        ]
+                    }
+                ],
+                "summary": "Delete policies",
+                "tags": [
+                    "policies"
+                ]
+            }
+        },
+        "/tags": {
+            "get": {
+                "description": "Retrieves all tag and ID mappings. Tags are unique identifiers assigned to policy groups for network policy enforcement.",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "tags": {
+                                            "items": {
+                                                "$ref": "#/components/schemas/Tag"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": "Successfully retrieved tags"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal server error"
+                    }
+                },
+                "security": [
+                    {
+                        "OAuth2Application": [
+                            "network.admin"
+                        ]
+                    }
+                ],
+                "summary": "List tags",
+                "tags": [
+                    "tags"
+                ]
+            }
+        }
+    },
+    "openapi": "3.1.0"
+}

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -1,0 +1,256 @@
+components:
+  schemas:
+    Destination:
+      properties:
+        id:
+          type: string
+        ips:
+          items:
+            $ref: '#/components/schemas/IPRange'
+          type: array
+          uniqueItems: false
+        ports:
+          $ref: '#/components/schemas/Ports'
+        protocol:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+      type: object
+    ErrorResponse:
+      properties:
+        error:
+          type: string
+        metadata:
+          additionalProperties: {}
+          type: object
+      type: object
+    IPRange:
+      properties:
+        end:
+          type: string
+        start:
+          type: string
+      type: object
+    PoliciesPayload:
+      properties:
+        policies:
+          items:
+            $ref: '#/components/schemas/Policy'
+          type: array
+          uniqueItems: false
+        total_policies:
+          type: integer
+      type: object
+    Policy:
+      properties:
+        destination:
+          $ref: '#/components/schemas/Destination'
+        source:
+          $ref: '#/components/schemas/Source'
+      type: object
+    Ports:
+      properties:
+        end:
+          type: integer
+        start:
+          type: integer
+      type: object
+    Source:
+      properties:
+        id:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+      type: object
+    Tag:
+      properties:
+        id:
+          type: string
+        tag:
+          type: string
+        type:
+          type: string
+      type: object
+externalDocs:
+  description: ""
+  url: ""
+info:
+  contact:
+    name: Cloud Foundry Networking Team
+  description: API for managing network policies and tags in Cloud Foundry
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  title: CF Networking API
+  version: "1.0"
+openapi: 3.1.0
+paths:
+  /policies:
+    get:
+      description: Retrieves network policies. Can optionally filter policies by source
+        ID, destination ID, or specific policy group IDs.
+      parameters:
+      - description: Comma-separated policy group ID values
+        in: query
+        name: id
+        schema:
+          type: string
+      - description: Comma-separated source policy group ID values
+        in: query
+        name: source_id
+        schema:
+          type: string
+      - description: Comma-separated destination policy group ID values
+        in: query
+        name: dest_id
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PoliciesPayload'
+          description: Successfully retrieved policies
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      security:
+      - OAuth2Application:
+        - network.write
+      summary: List policies
+      tags:
+      - policies
+    post:
+      description: Creates network policies to allow traffic between applications.
+        Policies define which source applications can reach which destination applications
+        on specified protocols and ports.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/PoliciesPayload'
+                description: Policies to create
+                summary: policies
+        description: Policies to create
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Policies created successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Invalid request body or validation failed
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden - insufficient permissions or policy quota exceeded
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      security:
+      - OAuth2Application:
+        - network.write
+      summary: Create policies
+      tags:
+      - policies
+  /policies/delete:
+    post:
+      description: Deletes existing network policies. This removes the network connectivity
+        rules between the specified source and destination applications.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/PoliciesPayload'
+                description: Policies to delete
+                summary: policies
+        description: Policies to delete
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Policies deleted successfully
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Invalid request body or validation failed
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden - insufficient permissions
+        "406":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Unsupported API version
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      security:
+      - OAuth2Application:
+        - network.write
+      summary: Delete policies
+      tags:
+      - policies
+  /tags:
+    get:
+      description: Retrieves all tag and ID mappings. Tags are unique identifiers
+        assigned to policy groups for network policy enforcement.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                properties:
+                  tags:
+                    items:
+                      $ref: '#/components/schemas/Tag'
+                    type: array
+                type: object
+          description: Successfully retrieved tags
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      security:
+      - OAuth2Application:
+        - network.admin
+      summary: List tags
+      tags:
+      - tags

--- a/scripts/generate-swagger.sh
+++ b/scripts/generate-swagger.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+# Simple script to generate OpenAPI 3.1 specification for CF Networking API
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+POLICY_SERVER_DIR="$PROJECT_ROOT/src/code.cloudfoundry.org/policy-server"
+OUTPUT_DIR="$PROJECT_ROOT/docs/swagger"
+
+echo "🚀 Generating OpenAPI 3.1 specification..."
+
+# Install swag v2 if not present
+GOPATH=$(go env GOPATH)
+SWAG_CMD="$GOPATH/bin/swag"
+
+if ! [ -f "$SWAG_CMD" ] || ! $SWAG_CMD --version 2>/dev/null | grep -q "v2\."; then
+    echo "📦 Installing swag v2..."
+    go install github.com/swaggo/swag/v2/cmd/swag@latest
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Generate OpenAPI 3.1 specification
+cd "$POLICY_SERVER_DIR"
+$SWAG_CMD init \
+    --dir ./ \
+    --generalInfo cmd/policy-server/main.go \
+    --output "$OUTPUT_DIR" \
+    --outputTypes json,yaml \
+    --parseDependency \
+    --parseInternal \
+    --v3.1
+
+# Rename to openapi.*
+mv "$OUTPUT_DIR/swagger.yaml" "$OUTPUT_DIR/openapi.yaml"
+mv "$OUTPUT_DIR/swagger.json" "$OUTPUT_DIR/openapi.json"
+
+echo "✅ Generated:"
+echo "   • $OUTPUT_DIR/openapi.yaml"
+echo "   • $OUTPUT_DIR/openapi.json"

--- a/src/code.cloudfoundry.org/policy-server/api/api.go
+++ b/src/code.cloudfoundry.org/policy-server/api/api.go
@@ -21,18 +21,18 @@ type AsgMapper interface {
 type PoliciesPayload struct {
 	TotalPolicies int      `json:"total_policies"`
 	Policies      []Policy `json:"policies"`
-}
+} //@name PoliciesPayload
 
 type Policy struct {
 	Source      Source      `json:"source"`
 	Destination Destination `json:"destination"`
-}
+} //@name Policy
 
 type Source struct {
 	ID   string `json:"id"`
 	Tag  string `json:"tag,omitempty"`
 	Type string `json:"type,omitempty"`
-}
+} //@name Source
 
 type Destination struct {
 	ID       string    `json:"id"`
@@ -41,28 +41,28 @@ type Destination struct {
 	Ports    Ports     `json:"ports"`
 	Type     string    `json:"type,omitempty"`
 	IPs      []IPRange `json:"ips,omitempty"`
-}
+} //@name Destination
 
 type IPRange struct {
 	Start string `json:"start"`
 	End   string `json:"end"`
-}
+} //@name IPRange
 
 type Ports struct {
 	Start int `json:"start"`
 	End   int `json:"end"`
-}
+} //@name Ports
 
 type Tag struct {
 	ID   string `json:"id"`
 	Tag  string `json:"tag"`
 	Type string `json:"type"`
-}
+} //@name Tag
 
 type AsgsPayload struct {
 	Next           int             `json:"next"`
 	SecurityGroups []SecurityGroup `json:"security_groups"`
-}
+} //@name AsgsPayload
 
 type SecurityGroup struct {
 	Guid              string   `json:"guid"`
@@ -72,4 +72,9 @@ type SecurityGroup struct {
 	RunningDefault    bool     `json:"running_default"`
 	StagingSpaceGuids []string `json:"staging_space_guids"`
 	RunningSpaceGuids []string `json:"running_space_guids"`
-}
+} //@name SecurityGroup
+
+type ErrorResponse struct {
+	Error    string                 `json:"error"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+} //@name ErrorResponse

--- a/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
+++ b/src/code.cloudfoundry.org/policy-server/cmd/policy-server/main.go
@@ -1,3 +1,28 @@
+// Package main CF Networking API
+//
+// The CF Networking API is used for creating, deleting and listing network policies and tags.
+//
+// In order to communicate with the CF Networking API, a UAA oauth token with valid
+// `network.admin` or `network.write` scope is required. The CF admin by default
+// has `network.admin` scope, other users will need to have the proper scope
+// granted by an admin.
+//
+// Space developers with the `network.write` scope can configure policies for
+// applications in spaces for which they have the SpaceDeveloper role.
+//
+//	@title			CF Networking API
+//	@description	API for managing network policies and tags in Cloud Foundry
+//	@version		1.0
+//	@servers		url:https://api.bosh-lite.com/networking/v1/external description:CF Networking API
+//
+//	@contact.name	Cloud Foundry Networking Team
+//	@license.name	Apache 2.0
+//	@license.url	http://www.apache.org/licenses/LICENSE-2.0.html
+//
+//	@securityDefinitions.oauth2.clientCredentials OAuth2Application
+//	@tokenUrl		https://uaa.bosh-lite.com/oauth/token
+//	@scope.network.admin	Grants read and write access to network policies
+//	@scope.network.write	Grants write access to network policies
 package main
 
 import (

--- a/src/code.cloudfoundry.org/policy-server/handlers/policies_create.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/policies_create.go
@@ -49,6 +49,18 @@ func NewPoliciesCreate(store policyStore, mapper api.PolicyMapper,
 	}
 }
 
+// @Summary Create policies
+// @Description Creates network policies to allow traffic between applications. Policies define which source applications can reach which destination applications on specified protocols and ports.
+// @Tags policies
+// @Accept json
+// @Produce json
+// @Param policies body PoliciesPayload true "Policies to create"
+// @Success 200 {object} object{} "Policies created successfully"
+// @Failure 400 {object} ErrorResponse "Invalid request body or validation failed"
+// @Failure 403 {object} ErrorResponse "Forbidden - insufficient permissions or policy quota exceeded"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Router /policies [post]
+// @Security OAuth2Application[network.write]
 func (h *PoliciesCreate) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	logger := getLogger(req)
 	logger = logger.Session("create-policies")

--- a/src/code.cloudfoundry.org/policy-server/handlers/policies_delete.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/policies_delete.go
@@ -27,6 +27,19 @@ func NewPoliciesDelete(store policyStore, mapper api.PolicyMapper,
 	}
 }
 
+// @Summary Delete policies
+// @Description Deletes existing network policies. This removes the network connectivity rules between the specified source and destination applications.
+// @Tags policies
+// @Accept json
+// @Produce json
+// @Param policies body PoliciesPayload true "Policies to delete"
+// @Success 200 {object} object{} "Policies deleted successfully"
+// @Failure 400 {object} ErrorResponse "Invalid request body or validation failed"
+// @Failure 403 {object} ErrorResponse "Forbidden - insufficient permissions"
+// @Failure 406 {object} ErrorResponse "Unsupported API version"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Router /policies/delete [post]
+// @Security OAuth2Application[network.write]
 func (h *PoliciesDelete) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	logger := getLogger(req)
 	logger = logger.Session("delete-policies")

--- a/src/code.cloudfoundry.org/policy-server/handlers/policies_index.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/policies_index.go
@@ -34,6 +34,17 @@ func NewPoliciesIndex(store store.Store,
 	}
 }
 
+// @Summary List policies
+// @Description Retrieves network policies. Can optionally filter policies by source ID, destination ID, or specific policy group IDs.
+// @Tags policies
+// @Produce json
+// @Param id query string false "Comma-separated policy group ID values"
+// @Param source_id query string false "Comma-separated source policy group ID values"
+// @Param dest_id query string false "Comma-separated destination policy group ID values"
+// @Success 200 {object} PoliciesPayload "Successfully retrieved policies"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Router /policies [get]
+// @Security OAuth2Application[network.write]
 func (h *PoliciesIndex) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	logger := getLogger(req)
 	logger = logger.Session("index-policies")

--- a/src/code.cloudfoundry.org/policy-server/handlers/tags_index.go
+++ b/src/code.cloudfoundry.org/policy-server/handlers/tags_index.go
@@ -22,6 +22,14 @@ func NewTagsIndex(store store.TagStore, marshaler marshal.Marshaler, errorRespon
 	}
 }
 
+// @Summary List tags
+// @Description Retrieves all tag and ID mappings. Tags are unique identifiers assigned to policy groups for network policy enforcement.
+// @Tags tags
+// @Produce json
+// @Success 200 {object} object{tags=[]Tag} "Successfully retrieved tags"
+// @Failure 500 {object} ErrorResponse "Internal server error"
+// @Router /tags [get]
+// @Security OAuth2Application[network.admin]
 func (h *TagsIndex) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	logger := getLogger(req)
 	logger = logger.Session("index-tags")


### PR DESCRIPTION
Summary
---------------
- Generate complete Swagger documentation for policy server APIs
- Add interactive Swagger UI with comprehensive API explorer
- Implement automated documentation generation via script
- Document all policy CRUD operations (create, read, update, delete)  
- Add tags API documentation and endpoints
- Enhance API handlers with proper OpenAPI annotations
- Provide developer-friendly README with setup instructions


Backward Compatibility
---------------
Breaking Change: Yes
