### PR TITLE
Add mysql-8.4 support to create-docker-container.bash

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -18,6 +18,9 @@ CONTAINER_NAME="$REPO_NAME-$DB-docker-container"
 if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-8.0"
   DB="mysql"
+elif [[ "${DB}" == "mysql-8.4" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-mysql-8.4"
+  DB="mysql"
 elif [[ "${DB}" == "mysql-5.7" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-5.7"
   DB="mysql"


### PR DESCRIPTION


TNZ-99882
ai-assisted=yes

- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds a mysql-8.4 case that maps to cloudfoundry/tas-runtime-mysql-8.4 and sets DB=mysql, following the same pattern as all other mysql variants. Developers can now run DB=mysql-8.4 ./scripts/create-docker-container.bash.

Backward Compatibility
---------------
Breaking Change? No