### PR TITLE
fix mysql 9.7 compatibility in policy-server migrations

### DIFF
--- a/scripts/create-docker-container.bash
+++ b/scripts/create-docker-container.bash
@@ -21,6 +21,9 @@ if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
 elif [[ "${DB}" == "mysql-8.4" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-8.4"
   DB="mysql"
+elif [[ "${DB}" == "mysql-9.7" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-mysql-9.7"
+  DB="mysql"
 elif [[ "${DB}" == "mysql-5.7" ]]; then
   IMAGE="cloudfoundry/tas-runtime-mysql-5.7"
   DB="mysql"

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0001.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0001.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-15: Remove inline REFERENCES from MySQL CREATE TABLE statements in v0001 migrations
+
 package migrations
 
 var migration_v0001 = map[string][]string{
@@ -8,21 +13,21 @@ var migration_v0001 = map[string][]string{
 		UNIQUE (guid),
 		PRIMARY KEY (id)
 	);`,
-		`CREATE TABLE IF NOT EXISTS destinations (
-		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES "groups"(id),
-		port int,
-		protocol varchar(255),
-		UNIQUE (group_id, port, protocol),
-		PRIMARY KEY (id)
-	);`,
+	`CREATE TABLE IF NOT EXISTS destinations (
+	id int NOT NULL AUTO_INCREMENT,
+	group_id int,
+	port int,
+	protocol varchar(255),
+	UNIQUE (group_id, port, protocol),
+	PRIMARY KEY (id)
+);`,
 		`CREATE TABLE IF NOT EXISTS policies (
-		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES "groups"(id),
-		destination_id int REFERENCES destinations(id),
-		UNIQUE (group_id, destination_id),
-		PRIMARY KEY (id)
-	);`,
+	id int NOT NULL AUTO_INCREMENT,
+	group_id int,
+	destination_id int,
+	UNIQUE (group_id, destination_id),
+	PRIMARY KEY (id)
+);`,
 	},
 	"postgres": {
 		`CREATE TABLE IF NOT EXISTS groups (
@@ -66,14 +71,14 @@ var migration_modified_v0001 = map[string][]string{
 
 var migration_modified_v0001a = map[string][]string{
 	"mysql": {
-		`CREATE TABLE IF NOT EXISTS destinations (
-		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES "groups"(id),
-		port int,
-		protocol varchar(255),
-		UNIQUE (group_id, port, protocol),
-		PRIMARY KEY (id)
-	);`,
+	`CREATE TABLE IF NOT EXISTS destinations (
+	id int NOT NULL AUTO_INCREMENT,
+	group_id int,
+	port int,
+	protocol varchar(255),
+	UNIQUE (group_id, port, protocol),
+	PRIMARY KEY (id)
+);`,
 	},
 	"postgres": {
 		`CREATE TABLE IF NOT EXISTS destinations (
@@ -88,13 +93,13 @@ var migration_modified_v0001a = map[string][]string{
 
 var migration_modified_v0001b = map[string][]string{
 	"mysql": {
-		`CREATE TABLE IF NOT EXISTS policies (
-		id int NOT NULL AUTO_INCREMENT,
-		group_id int REFERENCES "groups"(id),
-		destination_id int REFERENCES destinations(id),
-		UNIQUE (group_id, destination_id),
-		PRIMARY KEY (id)
-	);`,
+	`CREATE TABLE IF NOT EXISTS policies (
+	id int NOT NULL AUTO_INCREMENT,
+	group_id int,
+	destination_id int,
+	UNIQUE (group_id, destination_id),
+	PRIMARY KEY (id)
+);`,
 	},
 	"postgres": {
 		`CREATE TABLE IF NOT EXISTS policies (

--- a/src/code.cloudfoundry.org/policy-server/store/migrations/v0002.go
+++ b/src/code.cloudfoundry.org/policy-server/store/migrations/v0002.go
@@ -13,6 +13,20 @@ BEGIN
  FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE t1
  WHERE TABLE_NAME='destinations' AND COLUMN_NAME= 'port' AND TABLE_SCHEMA=@databaseName;
 
+ SELECT CONSTRAINT_NAME INTO @fkName
+ FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+ WHERE TABLE_NAME='destinations' AND COLUMN_NAME='group_id'
+   AND TABLE_SCHEMA=@databaseName
+   AND REFERENCED_TABLE_NAME IS NOT NULL
+ LIMIT 1;
+
+ IF @fkName IS NOT NULL THEN
+   SET @dropFkQuery = CONCAT('ALTER TABLE destinations DROP FOREIGN KEY ', @fkName);
+   PREPARE stmtFk FROM @dropFkQuery;
+   EXECUTE stmtFk;
+   DEALLOCATE PREPARE stmtFk;
+ END IF;
+
  SET @query = CONCAT('ALTER TABLE destinations DROP INDEX ', @name);
 
  PREPARE stmt FROM @query;
@@ -23,6 +37,8 @@ BEGIN
  SET @databaseName = NULL;
  SET @query = NULL;
  SET @name = NULL;
+ SET @fkName = NULL;
+ SET @dropFkQuery = NULL;
 
 END;`,
 		`CALL drop_destination_index();`,
@@ -90,6 +106,20 @@ BEGIN
  FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE t1
  WHERE TABLE_NAME='destinations' AND COLUMN_NAME= 'port' AND TABLE_SCHEMA=@databaseName;
 
+ SELECT CONSTRAINT_NAME INTO @fkName
+ FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+ WHERE TABLE_NAME='destinations' AND COLUMN_NAME='group_id'
+   AND TABLE_SCHEMA=@databaseName
+   AND REFERENCED_TABLE_NAME IS NOT NULL
+ LIMIT 1;
+
+ IF @fkName IS NOT NULL THEN
+   SET @dropFkQuery = CONCAT('ALTER TABLE destinations DROP FOREIGN KEY ', @fkName);
+   PREPARE stmtFk FROM @dropFkQuery;
+   EXECUTE stmtFk;
+   DEALLOCATE PREPARE stmtFk;
+ END IF;
+
  SET @query = CONCAT('ALTER TABLE destinations DROP INDEX ', @name);
 
  PREPARE stmt FROM @query;
@@ -100,6 +130,8 @@ BEGIN
  SET @databaseName = NULL;
  SET @query = NULL;
  SET @name = NULL;
+ SET @fkName = NULL;
+ SET @dropFkQuery = NULL;
 
 END;`,
 	},


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
MySQL 9.7 changed two behaviors that broke migrations on fresh databases:

1. Inline REFERENCES in column definitions (e.g. 'group_id int REFERENCES groups(id)') were silently ignored by MySQL 5.6-8.4 per the MySQL reference manual. MySQL 9.7 now enforces them, creating unexpected FK constraints. Fixed by removing inline REFERENCES from all MySQL CREATE TABLE statements in v0001 migrations. Postgres blocks are unchanged since Postgres has always correctly enforced this syntax.

2. DROP INDEX on an index backing a FK constraint now fails with Error 1553. Fixed the drop_destination_index() stored procedure in v0002 to drop the FK constraint before dropping the index. The FK is not recreated since it was never enforced pre-9.7 and the test suite does not expect it to exist after this migration.


Backward Compatibility
---------------
Breaking Change? No
