### PR TITLE
fix: pin locket to v0.0.0-20260602143356-23bea5865010 via replace dir…

### DIFF
--- a/src/code.cloudfoundry.org/go.mod
+++ b/src/code.cloudfoundry.org/go.mod
@@ -3,6 +3,7 @@ module code.cloudfoundry.org
 go 1.25.8
 
 replace (
+	code.cloudfoundry.org/locket => code.cloudfoundry.org/locket v0.0.0-20260602143356-23bea5865010
 	example-apps/spammer => ../example-apps/spammer
 
 	github.com/nats-io/go-nats => github.com/nats-io/go-nats v1.5.1-0.20180331191609-247b2a84d8d0


### PR DESCRIPTION
…ective

Prevents go get -u from pulling the stale go.mod published by Cursor during the detangle-submodule-deps work.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes go bumping due to Clod clodding up version tags that are now cached in code.cloudfoundry.org and interfering with everything.


Backward Compatibility
---------------
Breaking Change? no